### PR TITLE
Increase timeout for git clone st2 repo step

### DIFF
--- a/actions/workflows/setup_st2.yaml
+++ b/actions/workflows/setup_st2.yaml
@@ -26,6 +26,7 @@ st2ci.setup_st2:
                 repo: <% $.repo %>
                 branch: <% $.repo_branch %>
                 target: <% $.repo_dir %>/st2_<% $.repo_branch %>
+                timeout: 120
             retry:
                 count: 3
                 delay: 3


### PR DESCRIPTION
The git clone of st2 repo is approaching close to 60 seconds on more than a few occasions.