### PR TITLE
Use build_params st2 commit sha if available

### DIFF
--- a/rules/st2_pkg_test_unstable_u14.yaml
+++ b/rules/st2_pkg_test_unstable_u14.yaml
@@ -21,7 +21,7 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: "st2-pkg-unstable-u14-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
+        hostname: "st2-pkg-unstable-u14-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}} {% endif %}"
         pkg_env: staging
         release: unstable
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u14.yaml
+++ b/rules/st2_pkg_test_unstable_u14.yaml
@@ -21,7 +21,7 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: "st2-pkg-unstable-u14-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}} {% endif %}"
+        hostname: "st2-pkg-unstable-u14-{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         pkg_env: staging
         release: unstable
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u14.yaml
+++ b/rules/st2_pkg_test_unstable_u14.yaml
@@ -21,7 +21,7 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: "st2-pkg-unstable-u14-{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
+        hostname: "st2-pkg-unstable-u14-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
         pkg_env: staging
         release: unstable
-        triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.committer_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"
+        triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_unstable_u14_enterprise.yaml
@@ -21,7 +21,7 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: "st2-pkg-unstable-u14-ent-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}} {% endif %}"
+        hostname: "st2-pkg-unstable-u14-ent-{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         pkg_env: staging
         release: unstable
         enterprise: true

--- a/rules/st2_pkg_test_unstable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_unstable_u14_enterprise.yaml
@@ -21,9 +21,9 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: "st2-pkg-unstable-u14-ent-{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
+        hostname: "st2-pkg-unstable-u14-ent-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
         pkg_env: staging
         release: unstable
         enterprise: true
         enterprise_key: "{{system.enterprise_key_stg_unstable}}"
-        triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.committer_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"
+        triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_unstable_u14_enterprise.yaml
@@ -21,7 +21,7 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: "st2-pkg-unstable-u14-ent-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
+        hostname: "st2-pkg-unstable-u14-ent-{% if trigger.body.payload.build_parameters %} {{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}} {% else %} {{trigger.body.payload.vcs_revision | truncate(10, False, '')}} {% endif %}"
         pkg_env: staging
         release: unstable
         enterprise: true


### PR DESCRIPTION
Context from slack:
```
lakstorm [11:10]  
Bah. Circle CI changed their payload. https://gist.github.com/lakshmi-kannan/b49719c89b30eb5858fe676798cabbe0#file-gistfile1-txt-L57

lakstorm [11:11]  
The committer_name is now GitHub :confused:

[11:11]  
I’ll update rule to use author_name instead.

[11:12]  
The problem is there are two paths to trigger e2e tests - A merge to st2packages -> e2e packaging tests or a merge to st2 -> st2-packages build -> e2e

[11:16]  
Here is the payload when there is a merge to st2 https://gist.github.com/lakshmi-kannan/7a7feae1a609c4cdcf13195301addd43#file-gistfile1-txt-L31 (See build_parameters) and here’s a commit to st2-packages https://gist.github.com/lakshmi-kannan/b49719c89b30eb5858fe676798cabbe0#file-gistfile1-txt-L43 (No build_parameters)
```