### PR TITLE
Retry st2_pkg_e2e_retry_on_failure flow on failure

### DIFF
--- a/policies/st2_pkg_e2e_tests_retry_on_failure.yaml
+++ b/policies/st2_pkg_e2e_tests_retry_on_failure.yaml
@@ -1,0 +1,10 @@
+---
+name: st2_pkg_e2e_retry_on_failure
+pack: st2ci
+description: Retry st2_pkg_e2e_test workflow on failure for up to 1 times to try to work around some intermediate / temporary issues.
+enabled: true
+resource_ref: st2ci.st2_pkg_e2e_test
+policy_type: action.retry
+parameters:
+    retry_on: failure
+    max_retry_count: 2


### PR DESCRIPTION
This should hopefully help up with intermediate / temporary issues.

It also means actual failure will now be indicated as two consequent workflow failures.