### PR TITLE
Fix invalid attribute name when accessing data in the result object.

### DIFF
--- a/actions/workflows/st2_pkg_promote.yaml
+++ b/actions/workflows/st2_pkg_promote.yaml
@@ -54,7 +54,7 @@ st2ci.st2_pkg_promote:
                 distro_version: <% $.distro_version %>
                 version: <% $.version %>
             publish:
-                pkgs_list: <% task(get_pkgs_list).result.result %>
+                pkgs_list: <% task(get_pkgs_list).result.body %>
             on-success:
                 - get_latest_pkg_rev: <% len($.pkgs_list) > 0 %>
                 - fail: <% len($.pkgs_list) <= 0 %>

--- a/actions/workflows/st2_pkg_promote_enterprise.yaml
+++ b/actions/workflows/st2_pkg_promote_enterprise.yaml
@@ -57,7 +57,7 @@ st2ci.st2_pkg_promote_enterprise:
             input:
                 repo: <% $.stg_repo %>
             publish:
-                pkgs_list: <% task(get_pkgs_list).result.result %>
+                pkgs_list: <% task(get_pkgs_list).result.body %>
             on-success:
                 - get_latest_pkg_rev: <% len($.pkgs_list) > 0 %>
                 - fail: <% len($.pkgs_list) <= 0 %>


### PR DESCRIPTION
It seems like we want to access `result.body` of the HTTP runner.

Here is the action result object:

```
result: 
 body:
 - created_at: '2016-02-12T16:28:22.000Z'
   distro_version: ubuntu/trusty
   downloads_count_url: /api/v1/repos/StackStorm/staging-
```