### PR TITLE
Pass filename_filter param to list_packages actions

### DIFF
--- a/actions/workflows/st2_pkg_promote.yaml
+++ b/actions/workflows/st2_pkg_promote.yaml
@@ -50,6 +50,7 @@ st2ci.st2_pkg_promote:
             action: packagecloud.list_packages
             input:
                 repo: <% $.stg_repo %>
+                filename_filter: *<% $.version %>*
             publish:
                 pkgs_list: <% task(get_pkgs_list).result.body %>
             on-success:

--- a/actions/workflows/st2_pkg_promote_enterprise.yaml
+++ b/actions/workflows/st2_pkg_promote_enterprise.yaml
@@ -56,6 +56,7 @@ st2ci.st2_pkg_promote_enterprise:
             action: packagecloud.list_packages
             input:
                 repo: <% $.stg_repo %>
+                filename_filter: *<% $.version %>*
             publish:
                 pkgs_list: <% task(get_pkgs_list).result.body %>
             on-success:


### PR DESCRIPTION
This way we pre-filter the result and don't overload Mistral.