### PR TITLE
Increase timeout for upgrade to enterprise script

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -110,6 +110,7 @@ st2ci.st2_pkg_e2e_test:
                 distro: <% $.distro %>
                 pkg_env: <% $.pkg_env %>
                 release: <% $.release %>
+                timeout: 120
             on-success:
                 - get_installed_version
         get_installed_version:


### PR DESCRIPTION
On EL6 the `upgrade_to_enterprise` script was continuing to fail because it would timeout. This change increases the timeout of that script in an attempt to resolve the issue on EL6.