### PR TITLE
Add policy to retry st2_pkg_e2e_test on failure up to 1 time

### DIFF
--- a/policies/retry_st2_pkg_e2e_test_on_failure.yaml
+++ b/policies/retry_st2_pkg_e2e_test_on_failure.yaml
@@ -1,0 +1,10 @@
+name: st2_pkg_e2e_test.retry_on_failure
+# Note: We retry this run on failure to try to avoid false positives
+# which are caused by intermediate networking issues and similar.
+description: Retry "st2_pkg_e2e_test" tests on failure for up to 1 times.
+enabled: true
+resource_ref: st2ci.st2_pkg_e2e_test
+policy_type: action.retry
+parameters:
+    retry_on: failure
+    max_retry_count: 2


### PR DESCRIPTION
This should hopefully save us some time and reduce the amount of false positives due to intermediate failures we can't directly control (networking issues, etc.).