### PR TITLE
Verify services (MongoDB, RabbitMQ and PostgreSQL) only listen on localhost

### DIFF
--- a/actions/verify_service_only_listens_on_localhost.sh
+++ b/actions/verify_service_only_listens_on_localhost.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Script which verifies that service running on the provided port is only bound
+# to localhost (127.0.0.1)
+
+PORT=$1
+
+OUTPUT=$(sudo netstat -tlpn | grep \:\:\:${PORT}| wc -l)
+if [ ${OUTPUT} -eq 1 ]; then
+    echo "Service for port ${PORT} is bound on all the interfaces"
+    echo ""
+    echo $(sudo netstat -tlpn | grep \:\:\:${PORT})
+    exit 1
+fi
+
+OUTPUT=$(sudo netstat -tlpn | grep 127.0.0.1\:${PORT}| wc -l)
+if [ ${OUTPUT} -ne 1 ]; then
+    echo "Service not listening on 127.0.0.1:${PORT}"
+    exit 1
+fi
+
+OUTPUT=$(sudo netstat -tlpn | grep \:${PORT}| wc -l)
+if [ ${OUTPUT} -ne 1 ]; then
+    echo "Service listening on multiple interfaces / addresses for port ${PORT}"
+    echo ""
+    echo $(sudo netstat -tlpn | grep \:${PORT})
+    exit 1
+fi
+
+echo "All good, service only listening on 127.0.0.1:${PORT}"
+exit 0

--- a/actions/verify_service_only_listens_on_localhost.yaml
+++ b/actions/verify_service_only_listens_on_localhost.yaml
@@ -1,0 +1,12 @@
+---
+  name: "verify_service_only_listens_on_localhost"
+  runner_type: "run-remote-script"
+  description: "Verify that the service listening on the provided port is only bound / listening on localhost."
+  enabled: true
+  entry_point: "verify_service_only_listens_on_localhost.sh"
+  parameters:
+    port:
+      type: "integer"
+      description: "Port to check for."
+      required: true
+      position: 0

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -126,6 +126,27 @@ st2ci.st2_pkg_e2e_test:
                         task(get_installed_version).result.versions.items().select(
                             $[0] + "=" + $[1]).join("\n\t") %>
             on-success:
+                - verify_mongodb_only_listening_on_localhost
+        verify_mongodb_only_listening_on_localhost:
+            action: st2cd.verify_service_only_listens_on_localhost
+            input:
+                hosts: <% $.vm_info.private_ip_address %>
+                port: 27017
+            on-success:
+                - verify_rabbitmq_only_listening_on_localhost
+        verify_rabbitmq_only_listening_on_localhost:
+            action: st2cd.verify_service_only_listens_on_localhost
+            input:
+                hosts: <% $.vm_info.private_ip_address %>
+                port: 5672
+            on-success:
+                - verify_postgresql_only_listening_on_localhost
+        verify_postgresql_only_listening_on_localhost:
+            action: st2cd.verify_service_only_listens_on_localhost
+            input:
+                hosts: <% $.vm_info.private_ip_address %>
+                port: 5432
+            on-success:
                 - run_e2e_tests
         run_e2e_tests:
             action: st2cd.st2_e2e_tests


### PR DESCRIPTION
This pull request adds a check which verifies that the installer correctly configures services (MongoDB, RabbitMQ, PostgreSQL) to only listen on localhost.