### PR TITLE
Removed reference to undeclared vars in slack success message

### DIFF
--- a/actions/workflows/bwc_pkg_promote_all.yaml
+++ b/actions/workflows/bwc_pkg_promote_all.yaml
@@ -150,7 +150,7 @@ st2ci.bwc_pkg_promote_all:
             input:
                 channel: <% $.channel %>
                 text: ""
-                attachments: '[{"fallback": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "DISTRO: <% $.distro %>\nRELEASE: <% $.pkg_env %> <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nPACKAGE PROMOTED:\n\tbwc-enterprise-packages=<% $.promoted_bwc_enterprise %>\n\tst2-auth-ldap=<% $.promoted_st2_auth_ldap %>\n\tbwc-ipfabric-packs=<% $.promoted_bwc_ipfabric_packs %>\n\tbwc-topology=<% $.promoted_bwc_topology %>\n\tbwc-cli=<% $.promoted_bwc_cli %>\n\tbwc-ui=<% $.promoted_bwc_ui %>", "color": "<% $.notify_color %>"}]'
+                attachments: '[{"fallback": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "DISTRO: <% $.distro %>\nRELEASE: <% $.pkg_env %> <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nPACKAGE PROMOTED:\n\tbwc-enterprise-packages=<% $.promoted_bwc_enterprise %>\n\tst2-auth-ldap=<% $.promoted_st2_auth_ldap %>\n\tbwc-ui=<% $.promoted_bwc_ui %>", "color": "<% $.notify_color %>"}]'
 
         notify_failure:
             with-items: channel in <% $.notify_failure_channels %>

--- a/actions/workflows/bwc_pkg_promote_all.yaml
+++ b/actions/workflows/bwc_pkg_promote_all.yaml
@@ -150,7 +150,7 @@ st2ci.bwc_pkg_promote_all:
             input:
                 channel: <% $.channel %>
                 text: ""
-                attachments: '[{"fallback": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "DISTRO: <% $.distro %>\nRELEASE: <% $.pkg_env %> <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nPACKAGE PROMOTED:\n\tbwc-enterprise-packages=<% $.promoted_bwc_enterprise %>\n\tst2-auth-ldap=<% $.promoted_st2_auth_ldap %>\n\tbwc-ipfabric-suite=<% $.promoted_bwc_ipfabric_suite %>\n\tbwc-ipfabric-packs=<% $.promoted_bwc_ipfabric_packs %>\n\tbwc-topology=<% $.promoted_bwc_topology %>\n\tbwc-cli=<% $.promoted_bwc_cli %>\n\tbwc-ui=<% $.promoted_bwc_ui %>", "color": "<% $.notify_color %>"}]'
+                attachments: '[{"fallback": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title": "[st2ci.bwc_pkg_promote_all: COMPLETED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "DISTRO: <% $.distro %>\nRELEASE: <% $.pkg_env %> <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nPACKAGE PROMOTED:\n\tbwc-enterprise-packages=<% $.promoted_bwc_enterprise %>\n\tst2-auth-ldap=<% $.promoted_st2_auth_ldap %>\n\tbwc-ipfabric-packs=<% $.promoted_bwc_ipfabric_packs %>\n\tbwc-topology=<% $.promoted_bwc_topology %>\n\tbwc-cli=<% $.promoted_bwc_cli %>\n\tbwc-ui=<% $.promoted_bwc_ui %>", "color": "<% $.notify_color %>"}]'
 
         notify_failure:
             with-items: channel in <% $.notify_failure_channels %>


### PR DESCRIPTION
https://github.com/StackStorm/st2ci/commit/cd11fb4bf71593506995f950383921c0cb64eed1 removed several published variables in the workflow to promote BWC packages:

- promoted_bwc_ipfabric_suite
- promoted_bwc_ipfabric_packs
- promoted_bwc_topology
- promoted_bwc_cli

However, these vars are still referenced in the final success message sent to slack, and it's causing the workflow to return a "failed" result. This PR removes these vars from the slack message.