### PR TITLE
Increase timeout for the test task

### DIFF
--- a/actions/workflows/mistral.yaml
+++ b/actions/workflows/mistral.yaml
@@ -89,7 +89,7 @@ workflows:
                     hosts: <% $.hosts.get(test) %>
                     cwd: <% task(setup).result.clones.get(st2) %>
                     cmd: make mistral-itests 2>&1 | tee /tmp/mistral-itests-output.txt
-                    timeout: 600
+                    timeout: 900
                 on-success:
                     - record_pip_freeze
             record_pip_freeze:


### PR DESCRIPTION
The number of tests has increased and the timeout needs to accomodate.