### PR TITLE
Moved services stop task so that the enterprise upgrade doesn't restart services

### DIFF
--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -107,17 +107,8 @@ st2ci.st2_pkg_upgrade_e2e_test:
                 cmd: bash /tmp/st2_bootstrap.sh --<% $.pkg_env %> --<% $.release %> --version=<% coalesce($.upgrade_from_version, '') %> --user=<% $.st2_username %> --password=<% $.st2_password %>
                 timeout: 900
             on-success:
-                - pre_upgrade_stop
-
-        pre_upgrade_stop:
-            action: core.remote_sudo
-            input:
-                hosts: <% $.vm_info.private_ip_address %>
-                cmd: st2ctl stop
-                timeout: 180
-            on-complete:
               - install_enterprise: <% $.enterprise %>
-              - get_installed_version: <% not $.enterprise %>
+              - pre_upgrade_stop: <% not $.enterprise %>
 
         install_enterprise:
             action: st2cd.st2_upgrade_to_enterprise
@@ -129,6 +120,15 @@ st2ci.st2_pkg_upgrade_e2e_test:
                 release: <% $.release %>
                 version: <% coalesce($.upgrade_from_version, '') %>
             on-success:
+                - pre_upgrade_stop
+
+        pre_upgrade_stop:
+            action: core.remote_sudo
+            input:
+                hosts: <% $.vm_info.private_ip_address %>
+                cmd: st2ctl stop
+                timeout: 180
+            on-complete:
                 - get_installed_version
 
         get_installed_version:


### PR DESCRIPTION
https://github.com/StackStorm/st2ci/pull/77 added a task to stop all st2 services before updating stackstorm to the new version. The primarily intention of this was to ensure mistral isn't running on the new version before we can run the database migration tasks later on in the workflow. If you don't do this, you'll see [error messages](https://gist.github.com/Mierdin/08b60819d81761dd631e4e3e8121c2a3) that indicate a table already exists when performing the database migration.

While this worked for community upgrade tests, the enterprise workflow installs the enterprise packages (`st2cd.st2_upgrade_to_enterprise`), and appears to restart all st2 services, which effectively nullifies this services stop task. So, this PR re-orders these tasks so that whether we're testing community, or enterprise, the very last thing we do before the update to the new version of stackstorm is stop services.
