### PR TITLE
Enable system-wide debug mode

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -153,6 +153,15 @@ st2ci.st2_pkg_e2e_test:
                         task(get_installed_version).result.versions.items().select(
                             $[0] + "=" + $[1]).join("\n\t") %>
             on-success:
+                - run_e2e_tests: <% not $.debug %>
+                - enable_debug_mode: <% $.debug %>
+        enable_debug_mode:
+            action: core.remote_sudo
+            input:
+                hosts: <% $.vm_info.private_ip_address %>
+                cmd: crudini --set /etc/st2/st2.conf system debug True && st2ctl restart
+                timeout: 120
+            on-success:
                 - run_e2e_tests
         run_e2e_tests:
             action: st2cd.st2_e2e_tests


### PR DESCRIPTION
Event though we're running e2e test with debug flag, the logs it produces are often insufficient to properly diagnose the issue. This task will enable extensive logging before running any e2e tests.