### PR TITLE
Updated timeouts to reflect what's currently running on build node

### DIFF
--- a/actions/workflows/mistral.yaml
+++ b/actions/workflows/mistral.yaml
@@ -89,7 +89,7 @@ workflows:
                     hosts: <% $.hosts.get(test) %>
                     cwd: <% task(setup).result.clones.get(st2) %>
                     cmd: make mistral-itests 2>&1 | tee /tmp/mistral-itests-output.txt
-                    timeout: 900
+                    timeout: 3600
                 on-success:
                     - record_pip_freeze
             record_pip_freeze:

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -119,6 +119,7 @@ st2ci.st2_pkg_upgrade_e2e_test:
                 pkg_env: <% $.pkg_env %>
                 release: <% $.release %>
                 version: <% coalesce($.upgrade_from_version, '') %>
+                timeout: 120
             on-success:
                 - pre_upgrade_stop
 


### PR DESCRIPTION
At @humblearner request, I will not update the build node once this is merged. 