### PR TITLE
Remove --force-confnew DPKG option

### DIFF
--- a/actions/workflows/st2_pkg_upgrade_deb.yaml
+++ b/actions/workflows/st2_pkg_upgrade_deb.yaml
@@ -46,5 +46,5 @@ workflows:
             action: core.remote
             input:
                 hosts: <% $.host %>
-                cmd: sudo apt-get -y install --only-upgrade <% $.pkg_name_with_revision %>
+                cmd: sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y install --only-upgrade <% $.pkg_name_with_revision %>
                 timeout: 180

--- a/actions/workflows/st2_pkg_upgrade_deb.yaml
+++ b/actions/workflows/st2_pkg_upgrade_deb.yaml
@@ -46,5 +46,5 @@ workflows:
             action: core.remote
             input:
                 hosts: <% $.host %>
-                cmd: sudo apt-get -o Dpkg::Options::="--force-confnew" -y install --only-upgrade <% $.pkg_name_with_revision %>
+                cmd: sudo apt-get -y install --only-upgrade <% $.pkg_name_with_revision %>
                 timeout: 180


### PR DESCRIPTION
It breaks our upgrade tests when config has changed because existing
config with database credentials will get overwritten with a new empty
config without credentials and as such, upgrade will fail.