### PR TITLE
Fix for CircleCI build after st2 PR merge

### DIFF
--- a/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
@@ -11,9 +11,20 @@ criteria:
     trigger.body.payload.vcs_url:
         type: equals
         pattern: "https://github.com/StackStorm/st2"
+    # branch not starting with 'master' or 'vX.Y'
+    trigger.body.payload.branch:
+        type: regex
+        pattern: "^(?!master|v[0-9]+\\.[0-9]+).*$"
     trigger.body.payload.has_artifacts:
         type: equals
         pattern: true
+    trigger.body.payload.build_parameters:
+        type: exists
+        pattern: CIRCLE_JOB
+    # limit to 'packages' sub-task in CircleCI workflow
+    trigger.body.payload.build_parameters.CIRCLE_JOB:
+        type: equals
+        pattern: packages
     trigger.body.payload.pull_requests[0]:
         type: contains
         pattern: url

--- a/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
@@ -25,6 +25,8 @@ criteria:
     trigger.body.payload.build_parameters.CIRCLE_JOB:
         type: equals
         pattern: packages
+    # See bug: https://discuss.circleci.com/t/wrong-data-in-webhook-payload-for-workflows/15076
+    # when 'pull_requests' payload is included even for commits outside of PRs
     trigger.body.payload.pull_requests[0]:
         type: contains
         pattern: url

--- a/rules/st2_pkg_e2e_test_ubuntu16_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_ubuntu16_on_st2_pr.yaml
@@ -11,9 +11,21 @@ criteria:
     trigger.body.payload.vcs_url:
         type: equals
         pattern: "https://github.com/StackStorm/st2"
+    # branch not starting with 'master' or 'vX.Y'
+    trigger.body.payload.branch:
+        type: regex
+        pattern: "^(?!master|v[0-9]+\\.[0-9]+).*$"
     trigger.body.payload.has_artifacts:
         type: equals
         pattern: true
+    trigger.body.payload.build_parameters:
+        type: exists
+        pattern: CIRCLE_JOB
+    # limit to 'packages' sub-task in CircleCI workflow
+    trigger.body.payload.build_parameters.CIRCLE_JOB:
+        type: equals
+        pattern: packages
+    # 
     trigger.body.payload.pull_requests[0]:
         type: contains
         pattern: url

--- a/rules/st2_pkg_e2e_test_ubuntu16_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_ubuntu16_on_st2_pr.yaml
@@ -25,7 +25,8 @@ criteria:
     trigger.body.payload.build_parameters.CIRCLE_JOB:
         type: equals
         pattern: packages
-    # 
+    # See bug: https://discuss.circleci.com/t/wrong-data-in-webhook-payload-for-workflows/15076
+    # when 'pull_requests' payload is included even for commits outside of PRs
     trigger.body.payload.pull_requests[0]:
         type: contains
         pattern: url


### PR DESCRIPTION
Because of the bug in still fresh CircleCI 2.0 workflows, they include `PR` info for `master` branch, which shouldn't be there and so this triggers a build.

Adding more filters to trigger e2e tests only for PRs in `st2` repo.