### PR TITLE
Fix upgrade of dependencies for el7

### DIFF
--- a/actions/st2_pkg_upgrade_deps_el7.sh
+++ b/actions/st2_pkg_upgrade_deps_el7.sh
@@ -9,7 +9,7 @@ if [ ${SHORT_VERSION} = "2.4" ] && [ ${ENTERPRISE} -eq 0 ]; then
     echo "Upgrading dependencies for 2.4 community"
     curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -
     sudo yum clean all
-    sudo rpm -e --nodeps npm
+    sudo rpm -e --nodeps npm || true
     sudo yum update -y nodejs
     exit 0
 fi 


### PR DESCRIPTION
For some reason, npm package is not installed on the BWC installation.