### PR TITLE
Use FQDN for st2cicd

### DIFF
--- a/actions/workflows/bwc_pkg_promote_all.yaml
+++ b/actions/workflows/bwc_pkg_promote_all.yaml
@@ -44,7 +44,7 @@ st2ci.bwc_pkg_promote_all:
         init:
             action: core.noop
             publish:
-                webui_base_url: https://st2cicd
+                webui_base_url: https://st2cicd.uswest2.stackstorm.net
                 pkg_distro_version: <% $.distro_to_distro_version_map.get($.distro) %>
             on-success:
                 - notify_start

--- a/actions/workflows/mistral.yaml
+++ b/actions/workflows/mistral.yaml
@@ -44,7 +44,7 @@ workflows:
             init_vars:
                 action: core.noop
                 publish:
-                    webui_base_url: https://st2cicd
+                    webui_base_url: https://st2cicd.uswest2.stackstorm.net
                     is_infra_setup: False
                 on-success:
                     - notify_start

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -57,7 +57,7 @@ st2ci.st2_pkg_e2e_test:
         get_webui_server:
             action: core.noop
             publish:
-                webui_base_url: https://st2cicd
+                webui_base_url: https://st2cicd.uswest2.stackstorm.net
             on-success:
                 - notify_start
                 - set_github_status_pending: <% $.initial_commit != null %>

--- a/actions/workflows/st2_pkg_promote_all.yaml
+++ b/actions/workflows/st2_pkg_promote_all.yaml
@@ -40,7 +40,7 @@ st2ci.st2_pkg_promote_all:
         init:
             action: core.noop
             publish:
-                webui_base_url: https://st2cicd
+                webui_base_url: https://st2cicd.uswest2.stackstorm.net
                 pkg_distro_version: <% $.distro_to_distro_version_map.get($.distro) %>
             on-success:
                 - notify_start

--- a/actions/workflows/st2_pkg_test_and_promote.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote.yaml
@@ -35,7 +35,7 @@ st2ci.st2_pkg_test_and_promote:
         init:
             action: core.noop
             publish:
-                webui_base_url: https://st2cicd
+                webui_base_url: https://st2cicd.uswest2.stackstorm.net
                 pkg_distro_version: <% $.distro_to_distro_version_map.get($.distro) %>
             on-success:
                 - notify_start

--- a/actions/workflows/st2_pkg_test_and_promote_enterprise.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote_enterprise.yaml
@@ -26,7 +26,7 @@ st2ci.st2_pkg_test_and_promote_enterprise:
         init:
             action: core.noop
             publish:
-                webui_base_url: https://st2cicd
+                webui_base_url: https://st2cicd.uswest2.stackstorm.net
             on-success:
                 - notify_start
         notify_start:

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -52,7 +52,7 @@ st2ci.st2_pkg_upgrade_e2e_test:
         get_webui_server:
             action: core.noop
             publish:
-                webui_base_url: http://st2cicd
+                webui_base_url: http://st2cicd.uswest2.stackstorm.net
             on-success:
                 - notify_start
                 - create_vm


### PR DESCRIPTION
Use FQDN for `st2cicd` by default to get the best from https://github.com/StackStorm/ops-infra/issues/113 feature.