### PR TITLE
Explicitly pass version to upgrade_to_enterprise script

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -140,6 +140,7 @@ st2ci.st2_pkg_e2e_test:
                 distro: <% $.distro %>
                 pkg_env: <% $.pkg_env %>
                 release: <% $.release %>
+                version: <% coalesce($.version, '') %>
                 timeout: 150
             on-success:
                 - get_installed_version


### PR DESCRIPTION
Without explicit version, going back and doing CI testing patch releases for old versions (N-1, N-2...) will break CI. For example, if current stable version is 2.7.x and we want to ship a patch on 2.6, these changes force enterprise upgrade to 2.6.x. Without explicit version, enterprise upgrades would resort to latest stable enterprise bits and therefore our CI would actually not be testing the 2.6 combo of community + enterprise. 

Related: https://github.com/StackStorm/st2cd/pull/335