### PR TITLE
Added Window support to e2e tests

### DIFF
--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -29,6 +29,12 @@ parameters:
     keyfile:
         type: string
         default: /home/stanley/.ssh/stanley_rsa
+    windows_key_name:
+        type: string
+        default: st2_deploy_windows
+    windows_keyfile:
+        type: string
+        default: /home/stanley/st2_deploy_windows.pem
     distro:
         type: string
         required: true
@@ -39,6 +45,11 @@ parameters:
             - RHEL7
             - UBUNTU14
             - UBUNTU16
+    windows_distro:
+        type: string
+        enum:
+            - windows2016
+        default: windows2016
     role:
         type: string
         default: cislave

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -10,7 +10,10 @@ st2ci.st2_pkg_e2e_test:
         - environment
         - key_name
         - keyfile
+        - windows_key_name
+        - windows_keyfile
         - distro
+        - windows_distro
         - role
         - release
         - version
@@ -26,7 +29,10 @@ st2ci.st2_pkg_e2e_test:
 
     vars:
         vm_id: null
+        vm_windows_id: null
         vm_fqdn: <% $.hostname %>.<% $.dns_zone %>
+        windows_hostname: <% $.hostname %>win
+        vm_windows_fqdn: <% $.hostname %>win.<% $.dns_zone %>
         installed:
             version_str: not installed
         bootstrap_script_url: <% coalesce(
@@ -165,7 +171,27 @@ st2ci.st2_pkg_e2e_test:
                 cmd: crudini --set /etc/st2/st2.conf system debug True && st2ctl restart
                 timeout: 120
             on-success:
+                - create_vm_windows
+                
+        create_vm_windows:
+            action: st2cd.create_vm_windows
+            input:
+                hostname: <% $.windows_hostname %>
+                instance_type: <% $.instance_type %>
+                environment: <% $.environment %>
+                key_name: <% $.windows_key_name %>
+                keyfile: <% $.windows_keyfile %>
+                dns_zone: <% $.dns_zone %>
+                distro: <% $.windows_distro %>
+                role: <% $.role %>
+            publish:
+                vm_windows_info: <% task(create_vm_windows).result.vm_info %>
+                vm_windows_id: <% task(create_vm_windows).result.vm_info.id %>
+                vm_windows_username: <% task(create_vm_windows).result.vm_username %>
+                vm_windows_password: <% task(create_vm_windows).result.vm_password %>
+            on-success:
                 - run_e2e_tests
+                
         run_e2e_tests:
             action: st2cd.st2_e2e_tests
             input:
@@ -175,6 +201,10 @@ st2ci.st2_pkg_e2e_test:
                 version: <% $.version %>
                 st2_username: <% $.st2_username %>
                 st2_password: <% $.st2_password %>
+                windows_host_ip: <% $.vm_windows_info.private_ip_address %>
+                windows_host_fqdn: <% $.vm_windows_fqdn %>
+                windows_username: <% $.vm_windows_username %>
+                windows_password: <% $.vm_windows_password %>
             on-success:
                 - destroy_vm: <% not $.debug %>
                 - notify_success: <% $.debug %>
@@ -197,6 +227,17 @@ st2ci.st2_pkg_e2e_test:
             retry:
                 count: 2
                 delay: 30
+            on-complete:
+                - destroy_vm_windows
+
+        destroy_vm_windows:
+            action: st2cd.destroy_vm
+            input:
+                hostname: <% $.windows_hostname %>
+                instance_id: <% $.vm_windows_id %>
+            retry:
+                count: 2
+                delay: 30
             on-success:
                 - notify_success
             on-error:
@@ -211,10 +252,20 @@ st2ci.st2_pkg_e2e_test:
                 count: 2
                 delay: 30
             on-complete:
+                - destroy_vm_on_failure_windows
+                
+        destroy_vm_on_failure_windows:
+            action: st2cd.destroy_vm
+            input:
+                hostname: <% $.windows_hostname %>
+                instance_id: <% $.vm_windows_id %>
+            retry:
+                count: 2
+                delay: 30
+            on-complete:
                 - notify_failure
             on-error:
                 - noop
-
 
         notify_success:
             with-items: channel in <% $.notify_channels %>


### PR DESCRIPTION
Added support for creating and destroying Windows VMs in e2e tests. This also feeds windows credentials along to the actual e2e tests.