### PR TITLE
Removed st2-auth-ldap version hack

### DIFF
--- a/actions/workflows/bwc_pkg_promote_all.yaml
+++ b/actions/workflows/bwc_pkg_promote_all.yaml
@@ -87,11 +87,7 @@ st2ci.bwc_pkg_promote_all:
                 package: st2-auth-ldap
                 distro_version: <% $.pkg_distro_version %>
                 release: <% $.release %>
-                version: <%
-                    switch(
-                        dev in $.version => $.version.substring(0, $.version.indexOf(dev)) + '.dev0',
-                        $.version => $.version
-                    ) %>
+                version: <% $.version %>
             publish:
                 promoted_st2_auth_ldap: <% $.version + '-' + task(promote_st2_auth_ldap).result.revision %>
             on-complete:


### PR DESCRIPTION
Version hack no longer needed after https://github.com/StackStorm/st2-enterprise-auth-backend-ldap/pull/47