### PR TITLE
Use new c5 instance size for e2e tests

### DIFF
--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -15,7 +15,7 @@ parameters:
         default: uswest2.stackstorm.net
     instance_type:
         type: string
-        default: c4.large
+        default: c5.large
     environment:
         type: string
         enum:

--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -15,7 +15,8 @@ parameters:
         default: uswest2.stackstorm.net
     instance_type:
         type: string
-        default: c5.large
+        # There is no Centos 6 AMI which supports new C5 instance size
+        default: '{% if distro == "CENTOS6" %}c4.large{% else %}c5.large{% endif %}'
     environment:
         type: string
         enum:

--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -16,7 +16,7 @@ parameters:
     instance_type:
         type: string
         # There is no Centos 6 AMI which supports new C5 instance size
-        default: '{% if distro == "CENTOS6" %}c4.large{% else %}c5.large{% endif %}'
+        default: '{% if distro in ["CENTOS6", "RHEL6", "RHEL7"] %}c4.large{% else %}c5.large{% endif %}'
     environment:
         type: string
         enum:

--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -15,7 +15,7 @@ parameters:
         default: uswest2.stackstorm.net
     instance_type:
         type: string
-        # There is no Centos 6 AMI which supports new C5 instance size
+        # There is no AMI which supports new C5 instance size for those distros
         default: '{% if distro in ["CENTOS6", "RHEL6", "RHEL7"] %}c4.large{% else %}c5.large{% endif %}'
     environment:
         type: string

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -15,7 +15,7 @@ parameters:
         default: uswest2.stackstorm.net
     instance_type:
         type: string
-        default: c4.large
+        default: c5.large
     environment:
         type: string
         enum:

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -15,7 +15,8 @@ parameters:
         default: uswest2.stackstorm.net
     instance_type:
         type: string
-        default: c5.large
+        # There is no Centos 6 AMI which supports new C5 instance size
+        default: '{% if distro == "CENTOS6" %}c4.large{% else %}c5.large{% endif %}'
     environment:
         type: string
         enum:

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -16,7 +16,7 @@ parameters:
     instance_type:
         type: string
         # There is no Centos 6 AMI which supports new C5 instance size
-        default: '{% if distro == "CENTOS6" %}c4.large{% else %}c5.large{% endif %}'
+        default: '{% if distro in ["CENTOS6", "RHEL6", "RHEL7"] %}c4.large{% else %}c5.large{% endif %}'
     environment:
         type: string
         enum:

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -15,7 +15,7 @@ parameters:
         default: uswest2.stackstorm.net
     instance_type:
         type: string
-        # There is no Centos 6 AMI which supports new C5 instance size
+        # There is no AMI which supports new C5 instance size for those distros
         default: '{% if distro in ["CENTOS6", "RHEL6", "RHEL7"] %}c4.large{% else %}c5.large{% endif %}'
     environment:
         type: string


### PR DESCRIPTION
That size should be 10% faster than previous c4 one and it's also a bit cheaper.