### PR TITLE
Don't try to promote Ubuntu 18 packages

### DIFF
--- a/actions/bwc_pkg_promote_all.meta.yaml
+++ b/actions/bwc_pkg_promote_all.meta.yaml
@@ -14,7 +14,8 @@ parameters:
             - RHEL7
             - UBUNTU14
             - UBUNTU16
-            - UBUNTU18
+            # TODO: Uncomment when we officially support Bionic
+#            - UBUNTU18
     release:
         type: string
         required: true

--- a/actions/st2_pkg_promote_all.meta.yaml
+++ b/actions/st2_pkg_promote_all.meta.yaml
@@ -15,7 +15,7 @@ parameters:
             - UBUNTU14
             - UBUNTU16
             # TODO: Uncomment when we officially support Bionic
-            - UBUNTU18
+#            - UBUNTU18
     release:
         type: string
         required: true


### PR DESCRIPTION
We should uncomment that once we decide to start promoting Ubuntu 18.04 packages from staging unstable to other repos.