### PR TITLE
Update task sequence for st2_pkg_test_and_promote

### DIFF
--- a/actions/workflows/st2_pkg_test_and_promote.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote.yaml
@@ -70,16 +70,7 @@ tasks:
         publish:
           - versions: <% result().output.versions %>
           - version_str: <% result().output.versions.items().select( $[0] + "=" + $[1]).join("\n\t") %>
-        do: promote_all
-
-  promote_all:
-    action: core.noop
-    next:
-      - do:
-          - promote_st2
-          - promote_st2chatops
-          - promote_st2mistral
-          - promote_st2web
+        do: promote_st2
   promote_st2:
     action: st2ci.st2_pkg_promote
     input:
@@ -92,9 +83,9 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - promoted_st2: <% ctx().versions.get(st2) %>
-        do: process_completion
+        do: process_st2chatops
       - when: <% failed() %>
-        do: process_completion
+        do: process_st2chatops
   promote_st2chatops:
     action: st2ci.st2_pkg_promote
     input:
@@ -107,9 +98,9 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - promoted_st2chatops: <% ctx().versions.get(st2chatops) %>
-        do: process_completion
+        do: process_st2mistral
       - when: <% failed() %>
-        do: process_completion
+        do: process_st2mistral
   promote_st2mistral:
     action: st2ci.st2_pkg_promote
     input:
@@ -122,9 +113,9 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - promoted_st2mistral: <% ctx().versions.get(st2mistral) %>
-        do: process_completion
+        do: process_st2web
       - when: <% failed() %>
-        do: process_completion
+        do: process_st2web
   promote_st2web:
     action: st2ci.st2_pkg_promote
     input:
@@ -142,7 +133,6 @@ tasks:
         do: process_completion
 
   process_completion:
-    join: all
     action: core.noop
     next:
       - when: <% succeeded() and (ctx().promoted_st2 and ctx().promoted_st2chatops and ctx().promoted_st2mistral and ctx().promoted_st2web) %>

--- a/actions/workflows/st2_pkg_test_and_promote.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote.yaml
@@ -15,6 +15,11 @@ input:
       UBUNTU14: ubuntu/trusty
       UBUNTU16: ubuntu/xenial
       UBUNTU18: ubuntu/bionic
+  - mistral_supported_distros:
+    - RHEL6
+    - RHEL7
+    - UBUNTU14
+    - UBUNTU16
   - promoted_st2: false
   - promoted_st2chatops: false
   - promoted_st2mistral: false
@@ -98,9 +103,18 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - promoted_st2chatops: <% ctx().versions.get(st2chatops) %>
-        do: process_st2mistral
+        do: decide_process_st2mistral
       - when: <% failed() %>
-        do: process_st2mistral
+        do: decide_process_st2mistral
+  decide_process_st2mistral:
+    action: core.noop
+    next:
+      - when: <% ctx().distro in ctx().mistral_supported_distros %>
+        do: promote_st2mistral
+      - when: <% not ctx().distro in ctx().mistral_supported_distros %>
+        publish:
+          - promoted_st2mistral: true
+        do: promote_st2web
   promote_st2mistral:
     action: st2ci.st2_pkg_promote
     input:


### PR DESCRIPTION
Remove parallel branches due to bug with overwritten context vars and add logic to skip mistral for ubuntu 18.