### PR TITLE
Make sure output vars are already assigned

### DIFF
--- a/actions/workflows/mistral.yaml
+++ b/actions/workflows/mistral.yaml
@@ -29,6 +29,9 @@ input:
       - '#stackstorm'
 vars:
   - webui_base_url: https://st2cicd.uswest2.stackstorm.net
+  - hosts: null
+  - shas: null
+  - deps: null
 output:
   - hosts: <% ctx().hosts %>
   - shas: <% ctx().shas %>


### PR DESCRIPTION
The vars defined in output may not be assigned if the workflow fails. To avoid errors with referencing unassigned variables, initialize the variables in the vars section.