### PR TITLE
Complete all builds before noon

### DIFF
--- a/rules/st2_pkg_test_and_promote_unstable_el6.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el6.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 12
+    hour: 10
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_el6_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el6_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 15
+    hour: 11
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_el7.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 12
+    hour: 10
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_el7_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 15
+    hour: 11
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u14.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u14.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 12
+    hour: 10
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u14_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 15
+    hour: 11
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u16.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u16.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 12
+    hour: 10
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u16_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 15
+    hour: 11
     minute: 0
     second: 0
 


### PR DESCRIPTION
Per @m4dcoder request, change the build schedule so all builds complete in the morning. With this change, it is easier to perform maintenance and updates on our CI server in the afternoon.