### PR TITLE
Add auto-remediation step to cleanup on upgrade enterprise failure

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -168,6 +168,10 @@ tasks:
     next:
       - when: <% succeeded() %>
         do: check_debug_mode
+      - when: <% failed() %>
+        publish:
+          - failed: True
+        do: cleanup
   check_debug_mode:
     action: core.noop
     next:


### PR DESCRIPTION
On failure when upgrading to enterprise packages, add a task transition to cleanup.