### PR TITLE
[WIP] Automatically cancel old PR end to end builds when a new one is triggered

### DIFF
--- a/actions/cancel_old_builds.yaml
+++ b/actions/cancel_old_builds.yaml
@@ -1,0 +1,15 @@
+---
+name: cancel_old_builds_for_pr
+description: Action which looks for old st2_pkg_e2e_test builds for a particular builds and cancel any old / existing build.
+enabled: true
+runner_type: python-script
+entry_point: cancel_old_builds_for_pr.py
+parameters:
+  build_num:
+    type: string
+    description: "Circle CI build number."
+    required: true
+  pr_num:
+    type: string
+    description: "Github pull request number"
+    required: true

--- a/actions/cancel_old_builds_for_pr.py
+++ b/actions/cancel_old_builds_for_pr.py
@@ -1,0 +1,87 @@
+import os
+
+from st2common.runners.base_action import Action
+
+from st2client.client import Client
+
+ACTION_REF = 'st2ci.st2_pkg_e2e_test'
+
+
+class CancelOldBuildsForPrAction(Action):
+    def run(self, build_num, pr_num):
+        build_num = int(build_num)
+        pr_num = int(pr_num)
+
+        # 1. Find any matching executions
+        client = self._get_client()
+
+        execution_apis = client.liveactions.query(action=ACTION_REF, status='running', limit=100,
+                                                  include_attributes='id,status,parameters')
+
+        to_cancel_execution_apis = self._filter_executions(execution_apis,
+                                                           current_build_num=build_num,
+                                                           current_pr_num=pr_num)
+
+        to_cancel_execution_apis = execution_apis
+        self.logger.info('Found "%s" old execution(s) for PR "%s" to be canceled' %
+                         (len(to_cancel_execution_apis), pr_num))
+        # Make sure we exclude current one and not cancel the current / latest one
+
+        # 2. Cancel old ones
+        for execution_api in to_cancel_execution_apis:
+            msg = ('Canceling old execution with id "%s" for PR "%s" (build_num %s < '
+                   'current_build_num %s)' % (execution_api.id, pr_num,
+                                              execution_api.parameters['pr_num'], pr_num))
+            self.logger.info(msg)
+            client.liveactions.delete_by_id(execution_api.id)
+
+            # TODO: We should probably also ensure here that cleanup task is also called..
+
+    def _filter_executions(self, execution_apis, current_build_num, current_pr_num):
+        # Filter the executions and only return old ones
+        result = []
+
+        for execution_api in execution_apis:
+            parameters = execution_api.parameters
+
+            build_num = int(parameters.get('build_num', 0))
+            pr_num = int(parameters.get('pr_num', 0))
+
+            # Additional safety check to make sure we don't cancel current build
+            if build_num == current_build_num:
+                continue
+
+            # Skip executions for other PRs
+            if pr_num != current_pr_num:
+                continue
+
+            # Execution is considered as old if build_num is < current build num
+            if build_num and build_num < current_build_num:
+                result.apend(execution_api)
+
+        return result
+
+    def _get_client(self):
+        base_url, api_url, auth_url = self._get_st2_urls()
+
+        client_kwargs = {
+            'base_url': base_url,
+            'api_url': api_url,
+            'auth_url': auth_url,
+        }
+
+        token = self._get_auth_token()
+        client_kwargs['token'] = token
+
+        return Client(**client_kwargs)
+
+    def _get_st2_urls(self):
+        base_url = None
+        api_url = os.environ.get('ST2_ACTION_API_URL', None)
+        auth_url = os.environ.get('ST2_ACTION_AUTH_URL', None)
+
+        return base_url, api_url, auth_url
+
+    def _get_auth_token(self):
+        token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
+        return token

--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -66,6 +66,9 @@ parameters:
   dev_build:
     type: string
     description: Repo name + CircleCI build number ('st2/3126') to install artifacts from. Overrides version.
+  pr_num:
+    type: string
+    description: Github pull request number.
   initial_commit:
     type: string
     description: Git hash of an initial commit from st2 repo. If provided, the workflow will update status of this commit.

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -16,6 +16,7 @@ input:
   - release
   - version
   - dev_build
+  - pr_num
   - initial_commit
   - enterprise
   - enterprise_key
@@ -40,7 +41,7 @@ vars:
   - bootstrap_script_arg_dev_or_ver: <%
       switch(
         ctx().dev_build => "dev=" + ctx().dev_build,
-        not ctx().dev_build => "version=" + coalesce(ctx().version, '')) %> 
+        not ctx().dev_build => "version=" + coalesce(ctx().version, '')) %>
   - st2_username: st2admin
   - st2_password: Ch@ngeMe
   - github_status_org: StackStorm
@@ -68,7 +69,7 @@ tasks:
       - when: <% ctx().initial_commit != null %>
         do: set_github_status_pending
       - when: <% ctx().initial_commit = null %>
-        do: create_vm
+        do: cancel_old_builds_for_pr
   set_github_status_pending:
     action: github.add_status
     input:
@@ -81,8 +82,16 @@ tasks:
       target_url: <% ctx().github_status_url %>
     next:
       - when: <% succeeded() %>
-        do: create_vm
+        do: cancel_old_builds_for_pr
 
+  cancel_old_builds_for_pr:
+    action: st2ci.cancel_old_builds_for_pr
+    input:
+      build_num: <% ctx().dev_build %>
+      pr_num: <% ctx().pr_num %>
+    next:
+      - do:
+        - create_vm
   create_vm:
     action: st2cd.create_vm_role
     input:

--- a/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
@@ -42,6 +42,7 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "st2/{{trigger.body.payload.build_num}}"
+        pr_num: {{trigger.body.payload.pull_requests[0].url.split('/')[-1]}}
         initial_commit: "{{trigger.body.payload.vcs_revision}}"
         triggering_commit_url: |
           COMMITTER: {{trigger.body.payload.author_name}}


### PR DESCRIPTION
This pull request updates ``st2_pkg_e2e_test.meta`` action / workflow to cancel any existing old builds for a particular PR before starting a new one.

This is similar to Travis and Circle CI behavior of auto canceling of old builds when a new build is triggered by pushing changes to a branch. This allows us to speed things up and save resources and utilization on CICD.

To logic to determine old builds is simple - we check Circle CI build number and if that one is < current build number, then we mark that build as old and cancel it.

## TODO

- [ ] To ensure there are no stray resources left, we should update cancel action so it also triggers a new cleanup execution (``st2ci.st2_pkg_e2e_test_cleanup``) for a particular build. That action is idempotent so if it fails we can simply ignore it.