### PR TITLE
Change the schedule for the daily CI jobs

### DIFF
--- a/rules/st2_pkg_test_and_promote_unstable_el6.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el6.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 10
+    hour: 8
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_el6_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el6_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 11
+    hour: 9
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_el7.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 10
+    hour: 8
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_el7_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 11
+    hour: 9
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u14.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u14.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 10
+    hour: 8
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u14_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 11
+    hour: 9
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u16.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u16.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 10
+    hour: 8
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u16_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 11
+    hour: 9
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u18.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u18.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 12
+    hour: 8
     minute: 0
     second: 0
 

--- a/rules/st2_pkg_test_and_promote_unstable_u18_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u18_enterprise.yaml
@@ -8,7 +8,7 @@ trigger:
   type: core.st2.CronTimer
   parameters:
     timezone: US/Pacific
-    hour: 15
+    hour: 9
     minute: 0
     second: 0
 


### PR DESCRIPTION
Change the CI jobs to test and promote unstable packages to 8 AM PST and unstable enterprise packages to 9 AM PST.