### PR TITLE
Publish VM InstanceId on failure

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -107,6 +107,7 @@ tasks:
         do: get_bootstrap_script
       - when: <% failed() %>
         publish:
+          - vm_id: <% result().output.get("vm_info", {}).get("id") %>
           - failed: True
         do: cleanup
   patch_rhel6:
@@ -224,6 +225,7 @@ tasks:
         do: run_e2e_tests
       - when: <% failed() %>
         publish:
+          - vm_windows_id: <% result().output.get("vm_info", {}).get("id") %>
           - failed: True
         do: cleanup
   run_e2e_tests:


### PR DESCRIPTION
The create VM workflows can fail after the instance is already running in AWS. In this case, we still need the instance ID to destroy the VM on failure. Refactor the create VM workflows to try returning the instance ID.