### PR TITLE
Add chatops option to the e2e test for upgrade

### DIFF
--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -78,6 +78,9 @@ parameters:
     default: false
   enterprise_key:
     type: string
+  chatops:
+    type: boolean
+    default: false
   bootstrap_branch:
     type: string
     default: master

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -17,6 +17,7 @@ input:
   - upgrade_to_version
   - enterprise
   - enterprise_key
+  - chatops
   - pkg_env
   - bootstrap_branch
   - bootstrap_script
@@ -299,6 +300,7 @@ tasks:
       host_fqdn: <% ctx().vm_fqdn %>
       version: <% ctx().upgrade_to_version %>
       enterprise: <% ctx().enterprise %>
+      chatops: <% ctx().chatops %>
       st2_username: <% ctx().st2_username %>
       st2_password: <% ctx().st2_password %>
       windows_host_ip: <% ctx().vm_windows_info.get(private_ip_address) %>


### PR DESCRIPTION
Add chatops option to the e2e test for package upgrade and pass this option to the step that runs the e2e test.