### PR TITLE
Fix action trigger for circleci build event rules

### DIFF
--- a/rules/st2_pkg_test_unstable_u14_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u14_dev.yaml
@@ -31,5 +31,5 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "{{trigger.body.payload.build_num}}"
-        initial_commit: "{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA}}"
+        initial_commit: "{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u14_enterprise_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u14_enterprise_dev.yaml
@@ -31,7 +31,7 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "{{trigger.body.payload.build_num}}"
-        initial_commit: "{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA}}"
+        initial_commit: "{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         enterprise: true
         enterprise_key: "{{st2kv.system.enterprise_key_stg_unstable}}"
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u16_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u16_dev.yaml
@@ -31,5 +31,5 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "{{trigger.body.payload.build_num}}"
-        initial_commit: "{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA}}"
+        initial_commit: "{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u16_enterprise_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u16_enterprise_dev.yaml
@@ -31,7 +31,7 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "{{trigger.body.payload.build_num}}"
-        initial_commit: "{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA}}"
+        initial_commit: "{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         enterprise: true
         enterprise_key: "{{st2kv.system.enterprise_key_stg_unstable}}"
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u18_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u18_dev.yaml
@@ -31,5 +31,5 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "{{trigger.body.payload.build_num}}"
-        initial_commit: "{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA}}"
+        initial_commit: "{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"

--- a/rules/st2_pkg_test_unstable_u18_enterprise_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u18_enterprise_dev.yaml
@@ -31,7 +31,7 @@ action:
         pkg_env: staging
         release: unstable
         dev_build: "{{trigger.body.payload.build_num}}"
-        initial_commit: "{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA}}"
+        initial_commit: "{% if trigger.body.payload.build_parameters %}{{trigger.body.payload.build_parameters.ST2_COMMIT_SHA | truncate(10, False, '')}}{% else %}{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}{% endif %}"
         enterprise: true
         enterprise_key: "{{st2kv.system.enterprise_key_stg_unstable}}"
         triggering_commit_url: "PKG_BUILD_URL: {{trigger.body.payload.build_url}} {% if trigger.body.payload.build_parameters %}\n COMMITTER: {{trigger.body.payload.build_parameters.COMMITTER}} \n DIFF: {{trigger.body.payload.build_parameters.GITHUB_URL}} \n CIRCLE: {{trigger.body.payload.build_parameters.CIRCLE_URL}} {% else %} \n COMMITTER: {{trigger.body.payload.author_name}} \n DIFF: {{trigger.body.payload.compare}} {% endif %}"


### PR DESCRIPTION
The circleci build events from the release process does not have a ST2_COMMIT_SHA in the build parameters. The action execution of `st2ci.st2_pkg_e2e_test` being triggered are failing with error `Failed to render parameter "initial_commit"` because `has no attribute 'ST2_COMMIT_SHA'`. The value assignment of the `initial_commit` parameter is changed to the same if else Jinja expression for assigning hostname. If build_parameters are not present, then use the vcs_revision in the payload. Fixes #155 