### PR TITLE
Enable promotion of unstable bionic packages

### DIFF
--- a/actions/st2_pkg_test_and_promote_enterprise.meta.yaml
+++ b/actions/st2_pkg_test_and_promote_enterprise.meta.yaml
@@ -19,8 +19,7 @@ parameters:
       - RHEL7
       - UBUNTU14
       - UBUNTU16
-      # TODO: Uncomment when we support Bionic
-      #- UBUNTU18
+      - UBUNTU18
   release:
     type: string
     required: true


### PR DESCRIPTION
Add UBUNTU18 in the enum for supported distro for testing and promoting enterprise packages.