### PR TITLE
Obtain windows private key from st2kv storage

### DIFF
--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -30,12 +30,6 @@ parameters:
   keyfile:
     type: string
     default: /home/stanley/.ssh/stanley_rsa
-  windows_key_name:
-    type: string
-    default: st2_deploy_windows
-  windows_keyfile:
-    type: string
-    default: /home/stanley/st2_deploy_windows.pem
   distro:
     type: string
     required: true

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -30,12 +30,6 @@ parameters:
   keyfile:
     type: string
     default: /home/stanley/.ssh/stanley_rsa
-  windows_key_name:
-    type: string
-    default: st2_deploy_windows
-  windows_keyfile:
-    type: string
-    default: /home/stanley/st2_deploy_windows.pem
   distro:
     type: string
     required: true

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -8,8 +8,6 @@ input:
   - environment
   - key_name
   - keyfile
-  - windows_key_name
-  - windows_keyfile
   - distro
   - windows_distro
   - role
@@ -211,8 +209,6 @@ tasks:
       hostname: <% ctx().windows_hostname %>
       instance_type: <% ctx().instance_type %>
       environment: <% ctx().environment %>
-      key_name: <% ctx().windows_key_name %>
-      keyfile: <% ctx().windows_keyfile %>
       dns_zone: <% ctx().dns_zone %>
       distro: <% ctx().windows_distro %>
       role: <% ctx().role %>

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -7,8 +7,6 @@ input:
   - environment
   - key_name
   - keyfile
-  - windows_key_name
-  - windows_keyfile
   - distro
   - windows_distro
   - role
@@ -279,8 +277,6 @@ tasks:
       hostname: <% ctx().windows_hostname %>
       instance_type: <% ctx().instance_type %>
       environment: <% ctx().environment %>
-      key_name: <% ctx().windows_key_name %>
-      keyfile: <% ctx().windows_keyfile %>
       dns_zone: <% ctx().dns_zone %>
       distro: <% ctx().windows_distro %>
       role: <% ctx().role %>


### PR DESCRIPTION
Don't pass windows key during CI, use defaults from K/V based on st2cd repo workflows