### PR TITLE
Get st2 version from installed package

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -198,6 +198,7 @@ tasks:
               distro: <% result().output.distro %>
               versions: <% result().output.versions %>
               version_str: <% result().output.versions.items().select( $[0] + "=" + $[1]).join("\n\t") %>
+              st2_version: <% result().output.versions.get("st2") %>
         do: create_vm_windows
       - when: <% failed() %>
         publish:
@@ -232,7 +233,10 @@ tasks:
       host_fqdn: <% ctx().vm_fqdn %>
       enterprise: <% ctx().enterprise %>
       chatops: <% ctx().chatops %>
-      version: <% ctx().version %>
+      version: <% switch(
+        ctx().version != null => ctx().version,
+        "dev" in ctx().installed.st2_version => ctx().version,
+        not "dev" in ctx().installed.st2_version => ctx().installed.st2_version) %>
       st2_username: <% ctx().st2_username %>
       st2_password: <% ctx().st2_password %>
       windows_host_ip: <% ctx().vm_windows_info.private_ip_address %>


### PR DESCRIPTION
If version is provided as input to the e2e test, use the given version. If version is not provided to the e2e test, get the version from the installed st2 package. If the installed st2 package is a dev version, leave the version null. Otherwise, use the installed version which will dictate which st2tests branch to install.