### PR TITLE
Split out st2tests_version from ST2 version

### DIFF
--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -57,6 +57,10 @@ parameters:
       - stable
       - unstable
     default: stable
+  st2tests_version:
+    type: string
+    required: false
+    default: null
   version:
     type: string
   dev_build:

--- a/actions/st2_pkg_e2e_test_notify.meta.yaml
+++ b/actions/st2_pkg_e2e_test_notify.meta.yaml
@@ -24,6 +24,8 @@ parameters:
     type: string
   release:
     type: string
+  st2tests_version:
+    type: string
   version:
     type: string
   bootstrap_script_url:

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -12,6 +12,7 @@ input:
   - windows_distro
   - role
   - release
+  - st2tests_version
   - version
   - dev_build
   - initial_commit
@@ -233,8 +234,9 @@ tasks:
       host_fqdn: <% ctx().vm_fqdn %>
       enterprise: <% ctx().enterprise %>
       chatops: <% ctx().chatops %>
-      version: <% switch(
-        ctx().version != null => ctx().version,
+      st2tests_version: <% switch(
+        ctx().st2tests_version => ctx().st2tests_version,  # Tests actual false-y value
+        ctx().version != null => ctx().version,  # Tests equality to string "null"
         "dev" in ctx().installed.st2_version => ctx().version,
         not "dev" in ctx().installed.st2_version => ctx().installed.st2_version) %>
       st2_username: <% ctx().st2_username %>
@@ -279,6 +281,7 @@ tasks:
       enterprise: <% ctx().enterprise %>
       pkg_env: <% ctx().pkg_env %>
       release: <% ctx().release %>
+      st2tests_version: <% ctx().st2tests_version %>
       version: <% ctx().version %>
       bootstrap_script_url: <% ctx().bootstrap_script_url %>
       installed: <% ctx().installed %>

--- a/actions/workflows/st2_pkg_e2e_test_notify.yaml
+++ b/actions/workflows/st2_pkg_e2e_test_notify.yaml
@@ -11,6 +11,7 @@ input:
   - enterprise
   - pkg_env
   - release
+  - st2tests_version
   - version
   - bootstrap_script_url
   - installed
@@ -45,7 +46,7 @@ tasks:
     input:
       channel: <% item(channel) %>
       text: 'st2ci.st2_pkg_e2e_test: STARTED'
-      attachments: "[{\"fallback\": \"[st2ci.st2_pkg_e2e_test: STARTED]\", \"title\": \"[st2ci.st2_pkg_e2e_test: STARTED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().hostname %>\\nDISTRO: <% ctx().distro %>\\nENTERPRISE: <% ctx().enterprise %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nVERSION: <% coalesce(ctx().version, 'latest') %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#808080\"}]"
+      attachments: "[{\"fallback\": \"[st2ci.st2_pkg_e2e_test: STARTED]\", \"title\": \"[st2ci.st2_pkg_e2e_test: STARTED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().hostname %>\\nDISTRO: <% ctx().distro %>\\nENTERPRISE: <% ctx().enterprise %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nST2TESTS_VERSION: <% coalesce(ctx().st2tests_version, ctx().version, 'latest') %>\\nVERSION: <% coalesce(ctx().version, 'latest') %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#808080\"}]"
 
   notify_success:
     with: channel in <% ctx().notify_channels %>
@@ -53,7 +54,7 @@ tasks:
     input:
       channel: <% item(channel) %>
       text: 'st2ci.st2_pkg_e2e_test: SUCCEEDED'
-      attachments: "[{\"fallback\": \"[st2ci.st2_pkg_e2e_test: SUCCEEDED]\", \"title\": \"[st2ci.st2_pkg_e2e_test: SUCCEEDED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().hostname %>\\nDISTRO: <% ctx().distro %>\\nENTERPRISE: <% ctx().enterprise %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nVERSION: <% coalesce(ctx().version, 'latest') %>\\nVERSION INSTALLED:\\n\\t<% ctx().installed.version_str %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#008000\"}]"
+      attachments: "[{\"fallback\": \"[st2ci.st2_pkg_e2e_test: SUCCEEDED]\", \"title\": \"[st2ci.st2_pkg_e2e_test: SUCCEEDED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().hostname %>\\nDISTRO: <% ctx().distro %>\\nENTERPRISE: <% ctx().enterprise %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nST2TESTS_VERSION: <% coalesce(ctx().st2tests_version, ctx().version, 'latest') %>\\nVERSION: <% coalesce(ctx().version, 'latest') %>\\nVERSION INSTALLED:\\n\\t<% ctx().installed.version_str %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#008000\"}]"
     next:
       - when: <% ctx().initial_commit %>
         do: set_github_status_success
@@ -75,7 +76,7 @@ tasks:
     input:
       channel: <% item(channel) %>
       text: 'st2ci.st2_pkg_e2e_test: FAILED'
-      attachments: "[{\"fallback\": \"[st2ci.st2_pkg_e2e_test: FAILED]\", \"title\": \"[st2ci.st2_pkg_e2e_test: FAILED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().hostname %>\\nDISTRO: <% ctx().distro %>\\nENTERPRISE: <% ctx().enterprise %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nVERSION: <% coalesce(ctx().version, 'latest') %>\\nVERSION INSTALLED:\\n\\t<% ctx().installed.version_str %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#FF0000\"}]"
+      attachments: "[{\"fallback\": \"[st2ci.st2_pkg_e2e_test: FAILED]\", \"title\": \"[st2ci.st2_pkg_e2e_test: FAILED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().hostname %>\\nDISTRO: <% ctx().distro %>\\nENTERPRISE: <% ctx().enterprise %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nST2TESTS_VERSION: <% coalesce(ctx().st2tests_version, ctx().version, 'latest') %>\\nVERSION: <% coalesce(ctx().version, 'latest') %>\\nVERSION INSTALLED:\\n\\t<% ctx().installed.version_str %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#FF0000\"}]"
     next:
       - when: <% ctx().initial_commit %>
         do: set_github_status_failure

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -294,7 +294,7 @@ tasks:
     input:
       host_ip: <% ctx().vm_info.private_ip_address %>
       host_fqdn: <% ctx().vm_fqdn %>
-      version: <% ctx().upgrade_to_version %>
+      st2tests_version: <% ctx().upgrade_to_version %>
       enterprise: <% ctx().enterprise %>
       chatops: <% ctx().chatops %>
       st2_username: <% ctx().st2_username %>


### PR DESCRIPTION
This PR splits out the `st2tests_version` input parameter from StackStorm/st2cd#427 from the `version` input parameter.

I maintain backwards compatibility with just specifying the `version` parameter by using YAQL's `switch()` function and only using `st2tests_version` if it is defined. I also keep an existing bug with comparing `version` to the string `null`.

And just for clarity, I also tweak the Slack notification workflows to dump the st2tests branch as well.