### PR TITLE
Disable st2_pkg_test_and_promote_unstable_el8_enterprise

### DIFF
--- a/rules/st2_pkg_test_and_promote_unstable_el8_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el8_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_and_promote_unstable_el8_enterprise
 pack: st2ci
 description: Test and promote unstable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer


### PR DESCRIPTION
We don't have enterprise packages for RHEL 8 yet, so this CI run always fails.

Disable until we have enterprise packages built.