### PR TITLE
Promote packages in series after all

### DIFF
--- a/actions/workflows/bwc_pkg_promote_all.yaml
+++ b/actions/workflows/bwc_pkg_promote_all.yaml
@@ -59,11 +59,10 @@ tasks:
   promote_all:
     next:
       - do:
+          # Due to bug https://github.com/StackStorm/orquesta/issues/112,
+          # these tasks do not properly join to process_completion when run
+          # in parallel, so we run them sequential.
           - promote_bwc_enterprise
-          - promote_st2_auth_ldap
-          - promote_st2_rbac_backend
-          - promote_st2flow
-          - promote_bwc_ui
   promote_bwc_enterprise:
     action: st2ci.st2_pkg_promote_enterprise
     input:
@@ -76,12 +75,12 @@ tasks:
         publish:
           - promoted_bwc_enterprise: <% ctx().version + '-' + result().output.revision %>
         do:
-          - process_completion
+          - promote_st2_auth_ldap
       - when: <% failed() %>
         publish:
           - promoted_bwc_enterprise: false
         do:
-          - process_completion
+          - promote_st2_auth_ldap
   promote_st2_auth_ldap:
     action: st2ci.st2_pkg_promote_enterprise
     input:
@@ -94,12 +93,12 @@ tasks:
         publish:
           - promoted_st2_auth_ldap: <% ctx().version + '-' + result().output.revision %>
         do:
-          - process_completion
+          - promote_st2_rbac_backend
       - when: <% failed() %>
         publish:
           - promoted_st2_auth_ldap: false
         do:
-          - process_completion
+          - promote_st2_rbac_backend
   promote_st2_rbac_backend:
     action: st2ci.st2_pkg_promote_enterprise
     input:
@@ -112,12 +111,12 @@ tasks:
         publish:
           - promoted_st2_rbac_backend: <% ctx().version + '-' + result().output.revision %>
         do:
-          - process_completion
+          - promote_st2flow
       - when: <% failed() %>
         publish:
           - promoted_st2_rbac_backend: false
         do:
-          - process_completion
+          - promote_st2flow
   promote_st2flow:
     action: st2ci.st2_pkg_promote_enterprise
     input:
@@ -130,12 +129,12 @@ tasks:
         publish:
           - promoted_st2flow: <% ctx().version + '-' + result().output.revision %>
         do:
-          - process_completion
+          - promote_bwc_ui
       - when: <% failed() %>
         publish:
           - promoted_st2flow: false
         do:
-          - process_completion
+          - promote_bwc_ui
   promote_bwc_ui:
     action: st2ci.st2_pkg_promote_enterprise
     input:
@@ -156,8 +155,8 @@ tasks:
           - process_completion
 
   process_completion:
-    join: all
     action: core.noop
+
     next:
       - when: <% succeeded() and     (ctx().promoted_bwc_enterprise and ctx().promoted_st2_auth_ldap and ctx().promoted_st2_rbac_backend and ctx().promoted_st2flow and ctx().promoted_bwc_ui) %>
         publish:


### PR DESCRIPTION
The internal st2cicd server doesn't run a version of StackStorm that has a version of Orquesta with StackStorm/orquesta#112 applied, so it was premature to promote packages in parallel.

This undoes #169 and reverts commit 96ec939cea430dc7009bd2a15b1c8f45de61dd7f.

The correct time to tweak this back is after 3.2.0 is released and st2cicd is rebuilt to use that release (it is currently running 3.1.0).