### PR TITLE
Fix CentOS8 CI rule for st2 PR github status

### DIFF
--- a/rules/st2_pkg_e2e_test_centos8_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_centos8_on_st2_pr.yaml
@@ -38,7 +38,7 @@ action:
     ref: st2ci.st2_pkg_e2e_test
     parameters:
         hostname: "pkg-e2e-test-centos8-pr-st2-{{trigger.body.payload.build_num}}"
-        distro: CENTOS7
+        distro: CENTOS8
         pkg_env: staging
         release: unstable
         dev_build: "st2/{{trigger.body.payload.build_num}}"


### PR DESCRIPTION
Fixing an oversight introduced in https://github.com/StackStorm/st2ci/pull/162 which adds CentOS8 e2e check rule to stackstorm/st2 PRs, but used `centos7` distro instead of `centos8`.

That resulted in a wrong distro environment and missing centos8 status reported for Github PR.

Fixed status: ![](https://i.imgur.com/RYYIAaJ.png)

Example: https://github.com/StackStorm/st2/pull/4874