### PR TITLE
Use #opstown as alert channel instead of old #stackstorm

### DIFF
--- a/actions/workflows/bwc_pkg_promote_all.yaml
+++ b/actions/workflows/bwc_pkg_promote_all.yaml
@@ -18,7 +18,7 @@ input:
       - '#thunderdome'
   - notify_failure_channels:
       - '#thunderdome'
-      - '#stackstorm'
+      - '#opstown'
 vars:
   - webui_base_url: https://st2cicd.uswest2.stackstorm.net
   - promoted: false

--- a/actions/workflows/mistral.yaml
+++ b/actions/workflows/mistral.yaml
@@ -26,7 +26,7 @@ input:
       - '#thunderdome'
   - notify_failure_channels:
       - '#thunderdome'
-      - '#stackstorm'
+      - '#opstown'
 vars:
   - webui_base_url: https://st2cicd.uswest2.stackstorm.net
   - hosts: null

--- a/actions/workflows/st2_pkg_e2e_test_notify.yaml
+++ b/actions/workflows/st2_pkg_e2e_test_notify.yaml
@@ -26,7 +26,7 @@ vars:
       - '#thunderdome'
   - notify_failure_channels:
       - '#thunderdome'
-      - '#stackstorm'
+      - '#opstown'
 
 tasks:
   determine_which_notify:

--- a/actions/workflows/st2_pkg_promote_all.yaml
+++ b/actions/workflows/st2_pkg_promote_all.yaml
@@ -26,7 +26,7 @@ input:
       - '#thunderdome'
   - notify_failure_channels:
       - '#thunderdome'
-      - '#stackstorm'
+      - '#opstown'
 vars:
   - webui_base_url: https://st2cicd.uswest2.stackstorm.net
 output:

--- a/actions/workflows/st2_pkg_test_and_promote.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote.yaml
@@ -28,7 +28,7 @@ input:
     - '#thunderdome'
   - notify_failure_channels:
     - '#thunderdome'
-    - '#stackstorm'
+    - '#opstown'
 
 vars:
   - versions: ""

--- a/actions/workflows/st2_pkg_test_and_promote_enterprise.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote_enterprise.yaml
@@ -16,7 +16,7 @@ input:
     - '#thunderdome'
   - notify_failure_channels:
     - '#thunderdome'
-    - '#stackstorm'
+    - '#opstown'
 vars:
   - webui_base_url: https://st2cicd.uswest2.stackstorm.net
 tasks:

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -45,7 +45,7 @@ vars:
     - '#thunderdome'
   - notify_failure_channels:
     - '#thunderdome'
-    - '#stackstorm'
+    - '#opstown'
 output:
   - versions: <% ctx().installed.versions %>
 tasks:


### PR DESCRIPTION
Related to https://github.com/StackStorm/st2cd/pull/431