### PR TITLE
Fix syntax error in st2_pkg_upgrade_rpm

### DIFF
--- a/actions/workflows/st2_pkg_upgrade_rpm.yaml
+++ b/actions/workflows/st2_pkg_upgrade_rpm.yaml
@@ -12,8 +12,8 @@ tasks:
     action: core.noop
     next:
       - when: <% ctx().distro = 'CENTOS8' or ctx().distro = 'RHEL8' %>
-          do:
-            - upgrade_deps_el8
+        do:
+          - upgrade_deps_el8
       - when: <% ctx().distro = 'CENTOS7' or ctx().distro = 'RHEL7' %>
         do:
           - upgrade_deps_el7


### PR DESCRIPTION
During release testing we found a problem where `st2ci.st2_pkg_upgrade_rpm` threw the following error:

```
{
  "output": null,
  "errors": [
    {
      "message": "mapping values are not allowed here\n  in \"<string>\", line 15, column 13:\n              do:\n                ^"
    }
  ]
}
```

It looks like there were extra spaces before the `do` clause for el8.