### PR TITLE
removing extra fi

### DIFF
--- a/actions/st2_pkg_upgrade_deps_el8.sh
+++ b/actions/st2_pkg_upgrade_deps_el8.sh
@@ -10,5 +10,3 @@ SHORT_VERSION=`echo ${VERSION} | cut -d "." -f1-2`
 #    echo "Upgrading dependencies for 2.4 community"
 #    exit 0
 #fi
-
-fi


### PR DESCRIPTION
The `st2ci/actions/st2_pkg_upgrade_deps_el8.sh` file is not used in `v3.2` release. The `if...fi` loop was commented out incorrectly. 

Fixed. 