### PR TITLE
Fixing package upgrade e2e test for u18 and el8

### DIFF
--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -46,6 +46,15 @@ vars:
   - notify_failure_channels:
     - '#thunderdome'
     - '#opstown'
+  - pkg_list_legacy:
+    - st2
+    - st2mistral
+    - st2chatops
+    - st2web
+  - pkg_list_modern:
+    - st2
+    - st2chatops
+    - st2web
 output:
   - versions: <% ctx().installed.versions %>
 tasks:
@@ -161,6 +170,10 @@ tasks:
               distro: <% result().output.distro %>
               versions: <% result().output.versions %>
               version_str: <% result().output.versions.items().select( $[0] + "=" + $[1]).join("\n\t") %>
+          # determine the list of packages to upgrade base on OS
+          # modern OSes (el8+, u18+) do not have mistral and that is our default
+          # we have exceptions for the "legacy" cases as they will drop off with time
+          - pkg_list: <% switch(ctx().distro.endsWith('6') => ctx().pkg_list_legacy, ctx().distro.endsWith('7') => ctx().pkg_list_legacy, true => ctx().pkg_list_modern)  %>
         do:
           - upgrade_packages_rpm
       - when: <% succeeded() and ctx().distro.startsWith('UBUNTU') %>
@@ -169,17 +182,14 @@ tasks:
               distro: <% result().output.distro %>
               versions: <% result().output.versions %>
               version_str: <% result().output.versions.items().select( $[0] + "=" + $[1]).join("\n\t") %>
+          - pkg_list: <% switch(ctx().distro.endsWith('16') => ctx().pkg_list_legacy, true => ctx().pkg_list_modern) %>
         do:
           - upgrade_packages_deb
   upgrade_packages_rpm:
     action: st2ci.st2_pkg_upgrade_rpm
     input:
       host: <% ctx().vm_info.private_ip_address %>
-      pkg_list:
-        - st2
-        - st2mistral
-        - st2chatops
-        - st2web
+      pkg_list: <% ctx().pkg_list %>
       version: <% ctx().upgrade_to_version %>
       distro: <% ctx().distro %>
     next:
@@ -193,11 +203,7 @@ tasks:
     action: st2ci.st2_pkg_upgrade_deb
     input:
       host: <% ctx().vm_info.private_ip_address %>
-      pkg_list:
-        - st2
-        - st2mistral
-        - st2chatops
-        - st2web
+      pkg_list: <% ctx().pkg_list %>
       version: <% ctx().upgrade_to_version %>
       distro: <% ctx().distro %>
     next:


### PR DESCRIPTION
The list of packages to install was the same on every version of the os.

With us dropping Mistral support in u18 and el8 we were incorrectly trying to upgraded `st2mistral` on these OSes.

This PR adds a conditional exception for the "legacy" OSes (u16, el6, el7) to install the "legacy" packages which include `st2mistral`.

By default we'll install the "modern" packages on new OSes (u18+, el8+) without Mistral.

I coded it like this so when we add new OSes we do not need to make a new exception, they will install the right packages by default. However, when we remove an OS we can remove the exceptions and clean up the code.