### PR TITLE
Skip mistral SQL migrations on modern OSes that don't install Mistral

### DIFF
--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -195,7 +195,11 @@ tasks:
       - when: <% succeeded() and (ctx().enterprise) %>
         do:
           - upgrade_enterprise_packages_rpm
-      - when: <% succeeded() and (not ctx().enterprise) %>
+      # skip model migration for modern OSes where st2mistral is not present
+      - when: <% succeeded() and (not ctx().enterprise) and (ctx().distro = 'UBUNTU18') %>
+        do:
+          - post_migration_start
+      - when: <% succeeded() and (not ctx().enterprise) and (ctx().distro = 'UBUNTU16') %>
         do:
           - migrate_models
   upgrade_packages_deb:
@@ -209,7 +213,11 @@ tasks:
       - when: <% succeeded() and (ctx().enterprise) %>
         do:
           - upgrade_enterprise_packages_deb
-      - when: <% succeeded() and (not ctx().enterprise) %>
+      # skip model migration for modern OSes where st2mistral is not present
+      - when: <% succeeded() and (not ctx().enterprise) and (ctx().distro = 'RHEL8' or ctx().distro = 'CENTOS8') %>
+        do:
+          - post_migration_start
+      - when: <% succeeded() and (not ctx().enterprise) and (ctx().distro = 'RHEL7' or ctx().distro = 'CENTOS7' or ctx().distro = 'RHEL6' or ctx().distro = 'CENTOS6') %>
         do:
           - migrate_models
   upgrade_enterprise_packages_deb:
@@ -224,7 +232,11 @@ tasks:
       distro: <% ctx().distro %>
       enterprise: true
     next:
-      - when: <% succeeded() %>
+      # skip model migration for modern OSes where st2mistral is not present
+      - when: <% succeeded() and (ctx().distro = 'UBUNTU18') %>
+        do:
+          - post_migration_start
+      - when: <% succeeded() and (ctx().distro = 'UBUNTU16') %>
         do:
           - migrate_models
   upgrade_enterprise_packages_rpm:
@@ -239,7 +251,11 @@ tasks:
       distro: <% ctx().distro %>
       enterprise: true
     next:
-      - when: <% succeeded() %>
+      # skip model migration for modern OSes where st2mistral is not present
+      - when: <% succeeded() and (ctx().distro = 'RHEL8' or ctx().distro = 'CENTOS8') %>
+        do:
+          - post_migration_start
+      - when: <% succeeded() and (ctx().distro = 'RHEL7' or ctx().distro = 'CENTOS7' or ctx().distro = 'RHEL6' or ctx().distro = 'CENTOS6') %>
         do:
           - migrate_models
   migrate_models:


### PR DESCRIPTION
Should fix this:

```
"errors": [
    {
      "message": "Execution failed. See result for details.",
      "type": "error",
      "result": {
        "10.0.3.120": {
          "succeeded": false,
          "failed": true,
          "return_code": 127,
          "stderr": "Failed to stop mistral-api.service: Unit mistral-api.service not loaded.\nFailed to stop mistral-server.service: Unit mistral-server.service not loaded.\n/tmp/5ea7915d3cdb969b55585c07/st2_perform_migrations.sh: line 151: /opt/stackstorm/mistral/bin/mistral-db-manage: No such file or directory",
          "stdout": "--> No migrations to run for version 3.2\n############### ERROR ###############\n# Failed on step - Perform updates #\n#####################################"
        }
      },
      "task_id": "migrate_models"
    }
  ]
```