### PR TITLE
Disable the daily scheduled jobs for checking enterprise packages

### DIFF
--- a/rules/st2_pkg_test_and_promote_unstable_el7_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_and_promote_unstable_el7_enterprise
 pack: st2ci
 description: Test and promote unstable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_and_promote_unstable_el8_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el8_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_and_promote_unstable_el8_enterprise
 pack: st2ci
 description: Test and promote unstable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_and_promote_unstable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u16_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_and_promote_unstable_u16_enterprise
 pack: st2ci
 description: Test and promote unstable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_and_promote_unstable_u18_enterprise.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u18_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_and_promote_unstable_u18_enterprise
 pack: st2ci
 description: Test and promote unstable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_unstable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_unstable_u16_enterprise.yaml
@@ -1,7 +1,7 @@
 name: st2_pkg_test_unstable_u16_enterprise
 description: Run package tests on package build
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_test_unstable_u16_enterprise_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u16_enterprise_dev.yaml
@@ -1,7 +1,7 @@
 name: st2_pkg_test_unstable_u16_enterprise_dev
 description: Run package tests on dev package build
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_test_unstable_u16_enterprise_packaging.yaml
+++ b/rules/st2_pkg_test_unstable_u16_enterprise_packaging.yaml
@@ -1,7 +1,7 @@
 name: st2_pkg_test_unstable_u16_enterprise_packaging
 description: Run package tests on st2-packages package build
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_test_unstable_u18_enterprise.yaml
+++ b/rules/st2_pkg_test_unstable_u18_enterprise.yaml
@@ -1,7 +1,7 @@
 name: st2_pkg_test_unstable_u18_enterprise
 description: Run package tests on package build
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_test_unstable_u18_enterprise_dev.yaml
+++ b/rules/st2_pkg_test_unstable_u18_enterprise_dev.yaml
@@ -1,7 +1,7 @@
 name: st2_pkg_test_unstable_u18_enterprise_dev
 description: Run package tests on dev package build
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_test_unstable_u18_enterprise_packaging.yaml
+++ b/rules/st2_pkg_test_unstable_u18_enterprise_packaging.yaml
@@ -1,7 +1,7 @@
 name: st2_pkg_test_unstable_u18_enterprise_packaging
 description: Run package tests on st2-packages package build
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event


### PR DESCRIPTION
Extreme Networks is winding down support for enterprise packages. The daily scheduled CI jobs to check enterprise packages will be disabled.