### PR TITLE
Added -y to repoquery command so el8 imports GPG keys

### DIFF
--- a/actions/workflows/install_latest_revision_of_rpm_pkg.yaml
+++ b/actions/workflows/install_latest_revision_of_rpm_pkg.yaml
@@ -10,8 +10,8 @@ tasks:
     action: core.remote
     input:
       hosts: <% ctx().host %>
-      cmd: repoquery --show-duplicates <% ctx().pkg %>-<% ctx().version %>* | sort --version-sort | tail -n 1
-      timeout:
+      cmd: repoquery -y --show-duplicates <% ctx().pkg %>-<% ctx().version %>* | sort --version-sort | tail -n 1
+      timeout: 120
     next:
       - when: <% succeeded() %>
         publish:
@@ -24,3 +24,4 @@ tasks:
       hosts: <% ctx().host %>
       cmd: sudo yum install -y <% ctx().pkg_name_with_revision %>
       timeout: 180
+


### PR DESCRIPTION
Added `-y` to the `repoquery` command because it was getting stuck being prompted to import a GPG key from PackageCloud when testing out the EL8 upgrade e2e test.

This error was shown in the command output:

```StackStorm_staging-stable                       1.2 kB/s | 833  B     00:00    
StackStorm_staging-stable                        22 kB/s | 3.9 kB     00:00    
Importing GPG key 0x0A38E96F:
 Userid     : "https://packagecloud.io/StackStorm/staging-stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: A7FF A8B7 8DED 1ADC 2CDD A026 B1B9 A6E8 0A38 E96F
 From       : https://packagecloud.io/StackStorm/staging-stable/gpgkey
expand
```

When trying to run `yum makecache` the following was displayed:
```
StackStorm_staging-stable                       1.3 kB/s | 833  B     00:00    
StackStorm_staging-stable                        22 kB/s | 3.9 kB     00:00    
Importing GPG key 0x0A38E96F:
 Userid     : "https://packagecloud.io/StackStorm/staging-stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: A7FF A8B7 8DED 1ADC 2CDD A026 B1B9 A6E8 0A38 E96F
 From       : https://packagecloud.io/StackStorm/staging-stable/gpgkey
expand
Is this ok [y/N]: 
```

Adding a simple `-y` allows the key to be imported and `repoquery` to run successfully.