### PR TITLE
Added sudo to repoquery to import AWS RHEL repo SSL cert

### DIFF
--- a/actions/workflows/install_latest_revision_of_rpm_pkg.yaml
+++ b/actions/workflows/install_latest_revision_of_rpm_pkg.yaml
@@ -10,7 +10,7 @@ tasks:
     action: core.remote
     input:
       hosts: <% ctx().host %>
-      cmd: repoquery -y --show-duplicates <% ctx().pkg %>-<% ctx().version %>* | sort --version-sort | tail -n 1
+      cmd: sudo repoquery -y --show-duplicates <% ctx().pkg %>-<% ctx().version %>* | sort --version-sort | tail -n 1
       timeout: 120
     next:
       - when: <% succeeded() %>


### PR DESCRIPTION
This time the package upgrade workflow failed with the following error:

```
StackStorm_staging-stable                       1.3 kB/s | 833  B     00:00    
StackStorm_staging-stable                        23 kB/s | 3.9 kB     00:00    
Importing GPG key 0x0A38E96F:
 Userid     : \"https://packagecloud.io/StackStorm/staging-stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>\"
 Fingerprint: A7FF A8B7 8DED 1ADC 2CDD A026 B1B9 A6E8 0A38 E96F
 From       : https://packagecloud.io/StackStorm/staging-stable/gpgkey
StackStorm_staging-stable                       1.3 MB/s | 1.2 MB     00:00    
StackStorm_staging-stable-source                1.3 kB/s | 819  B     00:00    
StackStorm_staging-stable-source                 21 kB/s | 3.9 kB     00:00    
Importing GPG key 0x0A38E96F:
 Userid     : \"https://packagecloud.io/StackStorm/staging-stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>\"
 Fingerprint: A7FF A8B7 8DED 1ADC 2CDD A026 B1B9 A6E8 0A38 E96F
 From       : https://packagecloud.io/StackStorm/staging-stable/gpgkey
StackStorm_staging-stable-source                405  B/s | 296  B     00:00    
Extra Packages for Enterprise Linux Modular 8 - 142 kB/s |  97 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64   13 MB/s | 8.1 MB     00:00    
MongoDB Repository                               33 kB/s |  11 kB     00:00    
nginx repo                                       30 kB/s |  17 kB     00:00    
Node.js Packages for Enterprise Linux 8 - x86_6 1.0 MB/s | 306 kB     00:00    
rabbitmq_rabbitmq-server                        1.7 kB/s | 833  B     00:00    
rabbitmq_rabbitmq-server                         21 kB/s | 3.9 kB     00:00    
Importing GPG key 0x4D206F89:
 Userid     : \"https://packagecloud.io/rabbitmq/rabbitmq-server (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>\"
 Fingerprint: 8C69 5B02 19AF DEB0 4A05 8ED8 F4E7 8920 4D20 6F89
 From       : https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
rabbitmq_rabbitmq-server                         40 kB/s |  33 kB     00:00    
rabbitmq_rabbitmq-server-source                 1.6 kB/s | 819  B     00:00    
rabbitmq_rabbitmq-server-source                  23 kB/s | 3.9 kB     00:00    
Importing GPG key 0x4D206F89:
 Userid     : \"https://packagecloud.io/rabbitmq/rabbitmq-server (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>\"
 Fingerprint: 8C69 5B02 19AF DEB0 4A05 8ED8 F4E7 8920 4D20 6F89
 From       : https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
rabbitmq_rabbitmq-server-source                 404  B/s | 296  B     00:00    
Red Hat Update Infrastructure 3 Client Configur 0.0  B/s |   0  B     00:02    
Errors during downloading metadata for repository 'rhui-client-config-server-8':
  - Curl error (58): Problem with the local SSL certificate for https://rhui3.us-west-2.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/x86_64/os [could not load PEM client certificate, OpenSSL error error:0200100D:system library:fopen:Permission denied, (no key found, wrong pass phrase, or wrong file format?)]
Error: Failed to download metadata for repo 'rhui-client-config-server-8': Cannot prepare internal mirrorlist: Curl error (58): Problem with the local SSL certificate for https://rhui3.us-west-2.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/x86_64/os [could not load PEM client certificate, OpenSSL error error:0200100D:system library:fopen:Permission denied, (no key found, wrong pass phrase, or wrong file format?)]
```

`repoquery` wasn't able to import the SSL cert for the AWS RHEL repo because it was being run as a regular user, i added a `sudo ` here so that it can run elevated and have the proper permissions to import the SSL cert.

I re-ran the same action with `sudo` in front and got the following results:
![image](https://user-images.githubusercontent.com/3693851/96531463-b3078000-1257-11eb-81fa-ae9a0006466b.png)

Playing around i figured out why we run `core.remote` with `sudo` in the command vs `core.remote_sudo`. When running `core.remote_sudo` the following line is prepended to the output and messes with the output data that we want to use in a later command:
```
Waiting for process with pid 31684 to finish.
st2-0:3.3.0-4.x86_64
```

This is not what we want, so we use `core.remote` with `sudo` in the command like is there in the install command below.

```