### PR TITLE
Fixing RHEL/CentOS cache creation

### DIFF
--- a/actions/install_latest_revision_of_rpm_pkg.meta.yaml
+++ b/actions/install_latest_revision_of_rpm_pkg.meta.yaml
@@ -11,6 +11,14 @@ parameters:
     required: true
     description: >
       Host on which upgrade should be performed
+  distro:
+    type: string
+    required: true
+    enum:
+      - CENTOS7
+      - CENTOS8
+      - RHEL7
+      - RHEL8
   pkg:
     type: string
     required: true

--- a/actions/workflows/install_latest_revision_of_rpm_pkg.yaml
+++ b/actions/workflows/install_latest_revision_of_rpm_pkg.yaml
@@ -3,14 +3,36 @@ version: '1.0'
 description: Install latest revision of a specified rpm package
 input:
   - host
+  - distro
   - pkg
   - version
+
+vars:
+  - repoquery_args: ''
+
 tasks:
+  init:
+    action: core.noop
+    next:
+      - when: <% ctx().distro = 'CENTOS8' or ctx().distro = 'RHEL8' %>
+        # Run repoqery -y option in EL8 to do the following:
+        #  - import any GPG keys from new repos
+        #  - import any SSL certificates from new repos
+        publish:
+          - repoquery_args: '-y'
+        do:
+          - get_latest_revision
+      - when: <% ctx().distro = 'CENTOS7' or ctx().distro = 'RHEL7' %>
+        do:
+          - get_latest_revision
+
   get_latest_revision:
     action: core.remote
     input:
       hosts: <% ctx().host %>
-      cmd: sudo repoquery -y --show-duplicates <% ctx().pkg %>-<% ctx().version %>* | sort --version-sort | tail -n 1
+      # repoquery needs to be run with sudo so that it can import GPG keys and SSL certificates
+      # into the system locations, and the subsequent yum/rpm commands can succeed
+      cmd: sudo repoquery <% ctx().repoquery_args %> --show-duplicates <% ctx().pkg %>-<% ctx().version %>* | sort --version-sort | tail -n 1
       timeout: 120
     next:
       - when: <% succeeded() %>
@@ -18,6 +40,7 @@ tasks:
           - pkg_name_with_revision: <% result().get(ctx().host).stdout %>
         do:
           - upgrade_pkg_via_yum
+
   upgrade_pkg_via_yum:
     action: core.remote
     input:

--- a/actions/workflows/st2_pkg_upgrade_rpm.yaml
+++ b/actions/workflows/st2_pkg_upgrade_rpm.yaml
@@ -50,5 +50,6 @@ tasks:
     action: st2ci.install_latest_revision_of_rpm_pkg
     input:
       host: <% ctx().host %>
+      distro: <% ctx().distro %>
       pkg: <% item() %>
       version: <% ctx().version %>


### PR DESCRIPTION
Next problem:

RHEL/CentOS 7  doesn't recognize `repoquery -y` as a valid option. I think the "right" fix is to run `yum makecache` before running `repoquery` so that the cache, SSL certificates and GPG keys are all imported (hopefully).

To do this though, we need to run `sudo yum makecache -y` on EL8 and `sudo yum makecache -y fast` on EL7. Unfortunately EL8 doesn't allow the `fast` argument and EL7 takes too long to run plain `makecache`, so i have a switch in there to vary the arguments based on distro.