### PR TITLE
Check for Ubuntu 16.04 and conditionally install Python 3.6 and configure ST2 to use it

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -30,6 +30,7 @@ vars:
   - vm_windows_id:
   - vm_fqdn: <% ctx().hostname %>.<% ctx().dns_zone %>
   - vm_info:
+  - ubuntu_variant: ""
   - windows_hostname: <% ctx().hostname %>win
   - vm_windows_fqdn: <% ctx().hostname %>win.<% ctx().dns_zone %>
   - installed:
@@ -99,12 +100,38 @@ tasks:
         publish:
           - vm_info: <% result().output.vm_info %>
           - vm_id: <% result().output.vm_info.id %>
-        do: get_bootstrap_script
+        do: check_for_ubuntu_xenial
       - when: <% failed() %>
         publish:
           - vm_id: <% result().output.get("vm_info", {}).get("id") %>
           - failed: True
         do: cleanup
+  check_for_ubuntu_xenial:
+    action: core.remote
+    input:
+      hosts: <% ctx().vm_info.private_ip_address %>
+      cmd: cat /etc/issue
+    next:
+      - when: <% succeeded() and "Ubuntu 16" in result().get(ctx().vm_info.private_ip_address).stdout %>
+        publish:
+          - ubuntu_variant: "Ubuntu 16"
+        do: add_deadsnakes_ppa
+      - when: <% succeeded() and not "Ubuntu 16" in result().get(ctx().vm_info.private_ip_address).stdout %>
+        do: get_bootstrap_script
+      - when: <% failed() %>
+        do: check_debug_mode
+  add_deadsnakes_ppa:
+    action: core.remote_sudo
+    input:
+      hosts: <% ctx().vm_info.private_ip_address %>
+      cmd: |-
+        python3 --version
+        add-apt-repository ppa:deadsnakes/ppa --yes
+        apt-get update
+        apt-get install --yes python3.6
+    next:
+      - when: <% succeeded() %>
+        do: get_bootstrap_script
   get_bootstrap_script:
     action: core.remote_sudo
     input:
@@ -156,32 +183,6 @@ tasks:
     input:
       hosts: <% ctx().vm_info.private_ip_address %>
       timeout: 600
-    next:
-      - when: <% succeeded() %>
-        do: check_for_ubuntu_xenial
-  check_for_ubuntu_xenial:
-    action: core.remote
-    input:
-      hosts: <% ctx().vm_info.private_ip_address %>
-      cmd: grep 'Ubuntu 16' /etc/issue
-    next:
-      - when: <% succeeded() %>
-        do: install_python36
-      - when: <% failed() %>
-        do: check_debug_mode
-  install_python36:
-    action: core.remote_sudo
-    input:
-      hosts: <% ctx().vm_info.private_ip_address %>
-      cmd: |-
-        python3 --version
-        add-apt-repository ppa:deadsnakes/ppa --yes
-        apt-get update
-        apt-get install --yes python3.6
-        patch /etc/st2/st2.conf <<EOF
-        23a24
-        > python3_binary = /usr/bin/python3.6
-        EOF
     next:
       - when: <% succeeded() %>
         do: check_debug_mode

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -30,13 +30,13 @@ vars:
   - vm_windows_id:
   - vm_fqdn: <% ctx().hostname %>.<% ctx().dns_zone %>
   - vm_info:
-  - ubuntu_variant: ""
   - windows_hostname: <% ctx().hostname %>win
   - vm_windows_fqdn: <% ctx().hostname %>win.<% ctx().dns_zone %>
   - installed:
       distro:
       versions:
       version_str: not installed
+  - pipe_into_bootstrap_script: ""
   - bootstrap_script_url: <% coalesce(ctx().bootstrap_script, "https://raw.githubusercontent.com/StackStorm/st2-packages/" + ctx().bootstrap_branch + "/scripts/st2_bootstrap.sh") %>
   - bootstrap_script_arg_dev_or_ver: <%
       switch(
@@ -114,24 +114,12 @@ tasks:
     next:
       - when: <% succeeded() and "Ubuntu 16" in result().get(ctx().vm_info.private_ip_address).stdout %>
         publish:
-          - ubuntu_variant: "Ubuntu 16"
-        do: add_deadsnakes_ppa
+          - pipe_into_bootstrap_script: "echo 'y'"
+        do: get_bootstrap_script
       - when: <% succeeded() and not "Ubuntu 16" in result().get(ctx().vm_info.private_ip_address).stdout %>
         do: get_bootstrap_script
       - when: <% failed() %>
         do: check_debug_mode
-  add_deadsnakes_ppa:
-    action: core.remote_sudo
-    input:
-      hosts: <% ctx().vm_info.private_ip_address %>
-      cmd: |-
-        python3 --version
-        add-apt-repository ppa:deadsnakes/ppa --yes
-        apt-get update
-        apt-get install --yes python3.6
-    next:
-      - when: <% succeeded() %>
-        do: get_bootstrap_script
   get_bootstrap_script:
     action: core.remote_sudo
     input:
@@ -144,7 +132,10 @@ tasks:
     action: core.remote_sudo
     input:
       hosts: <% ctx().vm_info.private_ip_address %>
+      # If pipe_into_bootstrap_script is not empty, return it + " | "
+      # If pipe_into_bootstrap_script is empty, return an empty string
       cmd: >-
+        <% switch(ctx().pipe_into_bootstrap_script => concat(ctx().pipe_into_bootstrap_script, " | "), true => "") %>
         bash /tmp/st2_bootstrap.sh
         --<% ctx().pkg_env %>
         --<% ctx().release %>

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -158,6 +158,32 @@ tasks:
       timeout: 600
     next:
       - when: <% succeeded() %>
+        do: check_for_ubuntu_xenial
+  check_for_ubuntu_xenial:
+    action: core.remote
+    input:
+      hosts: <% ctx().vm_info.private_ip_address %>
+      cmd: grep 'Ubuntu 16' /etc/issue
+    next:
+      - when: <% succeeded() %>
+        do: install_python36
+      - when: <% failed() %>
+        do: check_debug_mode
+  install_python36:
+    action: core.remote_sudo
+    input:
+      hosts: <% ctx().vm_info.private_ip_address %>
+      cmd: |-
+        python3 --version
+        add-apt-repository ppa:deadsnakes/ppa --yes
+        apt-get update
+        apt-get install --yes python3.6
+        patch /etc/st2/st2.conf <<EOF
+        23a24
+        > python3_binary = /usr/bin/python3.6
+        EOF
+    next:
+      - when: <% succeeded() %>
         do: check_debug_mode
   check_debug_mode:
     action: core.noop


### PR DESCRIPTION
The end-to-end tests are failing on Ubuntu 16 because they don't have Python 3.6 available, which is blocking my PR #5064:

```
not ok 36 packs.setup_virtualenv with python3 flag works
# (in test file cli/test_pack_python3.bats, line 88)
#   `RESULT=$(st2 run examples.python_runner_print_python_version -j)' failed with status 127
not ok 37 python3 imports work correctly
# (from function `assert_success' in file cli/../test_helpers/bats-assert/src/assert.bash, line 114,
#  in test file cli/test_pack_python3.bats, line 117)
#   `assert_success' failed with status 127
# 
# -- command failed --
# status : 1
# output (19 lines):
#   
#   {
#       \"action\": {
#           \"ref\": \"python3_test.test_stdlib_import\"
#       }, 
#       \"context\": {
#           \"user\": \"st2admin\"
#       }, 
#       \"end_timestamp\": \"2020-10-29T00:47:52.928925Z\", 
#       \"id\": \"5f9a1138f016f26a2a042272\", 
#       \"result\": {
#           \"exit_code\": 1, 
#           \"result\": \"None\", 
#           \"stderr\": \"Traceback (most recent call last):\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/netaddr/compat.py\\\", line 91, in <module>\
    from importlib import resources as _importlib_resources\
ImportError: cannot import name 'resources'\
\
During handling of the above exception, another exception occurred:\
\
Traceback (most recent call last):\
  File \\\"/opt/stackstorm/st2/local/lib/python2.7/site-packages/python_runner/python_action_wrapper.py\\\", line 53, in <module>\
    from st2common import log as logging\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/log.py\\\", line 32, in <module>\
    from st2common.logging.handlers import FormatNamedFileHandler\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/logging/handlers.py\\\", line 22, in <module>\
    from oslo_config import cfg\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/oslo_config/cfg.py\\\", line 336, in <module>\
    from oslo_config import types\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/oslo_config/types.py\\\", line 21, in <module>\
    import netaddr\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/netaddr/__init__.py\\\", line 18, in <module>\
    from netaddr.core import (AddrConversionError, AddrFormatError,\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/netaddr/core.py\\\", line 11, in <module>\
    from netaddr.compat import _callable, _iter_dict_keys\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/netaddr/compat.py\\\", line 93, in <module>\
    import importlib_resources as _importlib_resources\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/importlib_resources/__init__.py\\\", line 31, in <module>\
    from importlib_resources._py3 import (\
  File \\\"/opt/stackstorm/st2/lib/python2.7/site-packages/importlib_resources/_py3.py\\\", line 20, in <module>\
    Resource = Union[str, os.PathLike]\
AttributeError: module 'os' has no attribute 'PathLike'\
\", 
#           \"stdout\": \"\"
#       }, 
#       \"start_timestamp\": \"2020-10-29T00:47:52.507461Z\", 
#       \"status\": \"failed\"
#   }
# --
# 
```

This PR tweaks the `st2_pkg_e2e_test` workflow to check for Ubuntu 16 and if detected, installs Python 3.6 from the `deadsnakes` PPA and configures StackStorm to use it utilizing the `patch` utility and Bash heredocs.