### PR TITLE
Use Orquesta features

### DIFF
--- a/actions/workflows/setup_st2.yaml
+++ b/actions/workflows/setup_st2.yaml
@@ -8,7 +8,6 @@ input:
   - repo_dir
   - debug
 vars:
-  - clone_repo_iteration_count: 0
   - clone_path: null
 output:
   - clone_path: <% ctx().clone_path %>
@@ -20,6 +19,9 @@ tasks:
           - clone_repo
   clone_repo:
     action: st2cd.git_clone
+    retry:
+      count: 3
+      delay: 3
     input:
       hosts: <% ctx().host %>
       repo: <% ctx().repo %>
@@ -27,12 +29,7 @@ tasks:
       target: <% ctx().repo_dir %>/st2_<% ctx().repo_branch %>
       timeout:
     next:
-      - when: <% failed() and ctx().clone_repo_iteration_count < 3 %>
-        publish:
-          - clone_repo_iteration_count: <% ctx().clone_repo_iteration_count + 1 %>
-        do:
-          - sleep_for_clone_repo
-      - when: <% failed() and ctx().clone_repo_iteration_count >= 3 %>
+      - when: <% failed() %>
         do:
           - teardown
       - when: <% succeeded() %>
@@ -40,15 +37,6 @@ tasks:
           - clone_path: <% result().get(ctx().host).stdout %>
         do:
           - install
-  sleep_for_clone_repo:
-    action: core.local
-    input:
-      cmd: sleep 3
-      timeout: null
-    next:
-      - when: <% succeeded() %>
-        do:
-          - clone_repo
   install:
     action: st2ci.install_st2
     input:

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -81,7 +81,9 @@ tasks:
       target_url: <% ctx().github_status_url %>
     next:
       - when: <% succeeded() %>
-        do: create_vm
+        do:
+          - create_vm
+          - create_vm_windows
 
   create_vm:
     action: st2cd.create_vm_role
@@ -186,11 +188,12 @@ tasks:
               versions: <% result().output.versions %>
               version_str: <% result().output.versions.items().select( $[0] + "=" + $[1]).join("\n\t") %>
               st2_version: <% result().output.versions.get("st2") %>
-        do: create_vm_windows
+        do: run_e2e_tests
       - when: <% failed() %>
         publish:
           - failed: True
         do: cleanup
+
   create_vm_windows:
     action: st2cd.create_vm_windows
     input:
@@ -213,7 +216,9 @@ tasks:
           - vm_windows_id: <% result().output.get("vm_info", {}).get("id") %>
           - failed: True
         do: cleanup
+
   run_e2e_tests:
+    join: all
     action: st2cd.st2_e2e_tests
     input:
       host_ip: <% ctx().vm_info.private_ip_address %>

--- a/actions/workflows/st2_pkg_e2e_test_cleanup.yaml
+++ b/actions/workflows/st2_pkg_e2e_test_cleanup.yaml
@@ -9,8 +9,6 @@ input:
   - debug
 
 vars:
-  - destroy_vm_retries: 0
-  - destroy_win_vm_retries: 0
   - failed: False
 
 output:
@@ -32,27 +30,29 @@ tasks:
         do: destroy_win_vm
 
   destroy_vm:
-    delay: 30
+    retry:
+      count: 2
+      delay: 30
     action: st2cd.destroy_vm
     input:
       hostname: <% ctx().hostname %>
       instance_id: <% ctx().vm_id %>
     next:
-      - when: <% failed() and ctx().destroy_vm_retries >= 2 %>
+      - when: <% failed() %>
         publish: failed=True
-      - when: <% failed() and ctx().destroy_vm_retries < 2 %>
-        publish: destroy_vm_retries=<% ctx().destroy_vm_retries + 1 %>
-        do: destroy_vm
 
   destroy_win_vm:
-    delay: 30
+    retry:
+      count: 2
+      delay: 30
     action: st2cd.destroy_vm
     input:
       hostname: <% ctx().win_hostname %>
       instance_id: <% ctx().win_vm_id %>
     next:
-      - when: <% failed() and ctx().destroy_win_vm_retries >= 2 %> 
+      - when: <% failed() %>
         publish: failed=True
-      - when: <% failed() and ctx().destroy_win_vm_retries < 2 %>
-        publish: destroy_win_vm_retries=<% ctx().destroy_win_vm_retries + 1 %>
-        do: destroy_win_vm
+
+# This workflow intentionally has two final, parallel tasks, destroy_vm and
+# destroy_win_vm to test that Orquesta correctly detects this and only
+# completes the workflow when both tasks have completed.

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -37,10 +37,6 @@ vars:
   - bootstrap_script_url: <% coalesce( ctx().bootstrap_script, "https://raw.githubusercontent.com/StackStorm/st2-packages/" + ctx().bootstrap_branch + "/scripts/st2_bootstrap.sh") %>
   - st2_username: st2admin
   - st2_password: Ch@ngeMe
-  - destroy_vm_iteration_count: 0
-  - destroy_vm_windows_iteration_count: 0
-  - destroy_vm_on_failure_iteration_count: 0
-  - destroy_vm_on_failure_windows_iteration_count: 0
   - notify_channels:
     - '#thunderdome'
   - notify_failure_channels:
@@ -280,6 +276,9 @@ tasks:
       attachments: "[{\"title\": \"[st2ci.st2_pkg_upgrade_e2e_test: STARTED]\", \"title_link\": \"<% ctx().webui_base_url %>/#/history/<% ctx().st2.action_execution_id %>/general\", \"text\": \"COMMIT: <% coalesce(ctx().triggering_commit_url, 'n/a') %>\\nHOSTNAME: <% ctx().vm_fqdn %>\\nDISTRO: <% ctx().distro %>\\nRELEASE: <% ctx().pkg_env %> <% ctx().release %>\\nFROM_VERSION: <% ctx().upgrade_from_version %>\\nTO_VERSION: <% ctx().upgrade_to_version %>\\nBOOTSTRAP: <% ctx().bootstrap_script_url %>\", \"color\": \"#808080\"}]"
   destroy_vm:
     action: st2cd.destroy_vm
+    retry:
+      count: 2
+      delay: 30
     input:
       hostname: <% ctx().hostname %>
       instance_id: <% ctx().vm_id %>
@@ -287,24 +286,14 @@ tasks:
       - when: <% succeeded() %>
         do:
           - destroy_vm_windows
-      - when: <% failed() and (ctx().destroy_vm_iteration_count >= 2) %>
+      - when: <% failed() %>
         do:
           - fail
-      - when: <% failed() and (ctx().destroy_vm_iteration_count < 2) %>
-        publish:
-          - destroy_vm_iteration_count: <% ctx().destroy_vm_iteration_count + 1 %>
-        do:
-          - sleep_destroy_vm
-  sleep_destroy_vm:
-    action: core.local
-    input:
-      cmd: sleep 30
-    next:
-      - when: <% succeeded() %>
-        do:
-          - destroy_vm
   destroy_vm_windows:
     action: st2cd.destroy_vm
+    retry:
+      count: 2
+      delay: 30
     input:
       hostname: <% ctx().windows_hostname %>
       instance_id: <% ctx().vm_windows_id %>
@@ -312,24 +301,14 @@ tasks:
       - when: <% succeeded() %>
         do:
           - notify_success
-      - when: <% failed() and (ctx().destroy_vm_windows_iteration_count >= 2) %>
+      - when: <% failed() %>
         do:
           - notify_failure
-      - when: <% failed() and (ctx().destroy_vm_windows_iteration_count < 2) %>
-        publish:
-          - destroy_vm_windows_iteration_count: <% ctx().destroy_vm_windows_iteration_count + 1 %>
-        do:
-          - sleep_destroy_vm_windows
-  sleep_destroy_vm_windows:
-    action: core.local
-    input:
-      cmd: sleep 30
-    next:
-      - when: <% succeeded() %>
-        do:
-          - destroy_vm_windows
   destroy_vm_on_failure:
     action: st2cd.destroy_vm
+    retry:
+      count: 2
+      delay: 30
     input:
       hostname: <% ctx().hostname %>
       instance_id: <% ctx().vm_id %>
@@ -337,44 +316,23 @@ tasks:
       - when: <% succeeded() %>
         do:
           - destroy_vm_on_failure_windows
-      - when: <% failed() and (ctx().destroy_vm_on_failure_iteration_count >= 2) %>
+      - when: <% failed() %>
         do:
           - destroy_vm_on_failure_windows
           - fail
-      - when: <% failed() and (ctx().destroy_vm_on_failure_iteration_count < 2) %>
-        do:
-          - sleep_destroy_vm_on_failure
-  sleep_destroy_vm_on_failure:
-    action: core.local
-    input:
-      cmd: sleep 30
-    next:
-      - when: <% succeeded() %>
-        do:
-          - destroy_vm_on_failure
   destroy_vm_on_failure_windows:
     action: st2cd.destroy_vm
+    retry:
+      count: 2
+      delay: 30
     input:
       hostname: <% ctx().windows_hostname %>
       instance_id: <% ctx().vm_windows_id %>
     next:
-      - when: <% succeeded() or (failed() and (ctx().destroy_vm_on_failure_windows_iteration_count >= 2)) %>
+      - when: <% succeeded() or failed() %>
         do:
           - notify_failure
           - fail
-      - when: <% failed() and (ctx().destroy_vm_on_failure_windows_iteration_count < 2) %>
-        publish:
-          - destroy_vm_on_failure_windows_iteration_count: <% ctx().destroy_vm_on_failure_windows_iteration_count + 1 %>
-        do:
-          - sleep_destroy_vm_on_failure_windows
-  sleep_destroy_vm_on_failure_windows:
-    action: core.local
-    input:
-      cmd: sleep 30
-    next:
-      - when: <% succeeded() %>
-        do:
-          - destroy_vm_on_failure_windows
   notify_success:
     with:
       items: channel in <% ctx().notify_channels %>


### PR DESCRIPTION
This PR updates our workflows to use Orquesta task retry instead of implementing that ourselves. Additionally, it launches tasks in parallel and uses `join: all` to wait on the completion of both tasks.