### PR TITLE
Test ChatOps end-to-end tests on daily CI builds

### DIFF
--- a/rules/st2_pkg_test_and_promote_unstable_el7.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7.yaml
@@ -20,3 +20,4 @@ action:
     hostname: st2-pkg-unstable-el7
     distro: RHEL7
     release: unstable
+    chatops: true

--- a/rules/st2_pkg_test_and_promote_unstable_el8.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el8.yaml
@@ -20,3 +20,4 @@ action:
     hostname: st2-pkg-unstable-el8
     distro: RHEL8
     release: unstable
+    chatops: true

--- a/rules/st2_pkg_test_and_promote_unstable_u16.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u16.yaml
@@ -20,3 +20,4 @@ action:
     hostname: st2-pkg-unstable-u16
     distro: UBUNTU16
     release: unstable
+    chatops: true

--- a/rules/st2_pkg_test_and_promote_unstable_u18.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u18.yaml
@@ -20,3 +20,4 @@ action:
     hostname: st2-pkg-unstable-u18
     distro: UBUNTU18
     release: unstable
+    chatops: true


### PR DESCRIPTION
Our stable daily builds tested ChatOps end-to-end, but our unstable builds did not. This PR simply sets that boolean parameter to `true` for the workflows.