### PR TITLE
Use the --u16-add-insecure-py3-ppa flag

### DIFF
--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -124,6 +124,7 @@ tasks:
         --<% ctx().bootstrap_script_arg_dev_or_ver %>
         --user=<% ctx().st2_username %>
         --password=<% ctx().st2_password %>
+        --u16-add-insecure-py3-ppa
       timeout: 900
     next:
       - when: <% succeeded() and (ctx().enterprise) %>


### PR DESCRIPTION
This tiny PR simply updates the task that runs the ST2 bootstrap script to pass the `--u16-add-insecure-py3-ppa` flag. It does this during all OSes, since the OS detection logic is later in the workflow. The install script is smart enough to ignore unrecognized flags.

Closes #194.