### PR TITLE
[WIP] Use larger EC2 instances for end to end tests

### DIFF
--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -16,7 +16,7 @@ parameters:
   instance_type:
     type: string
     # There is no AMI which supports new C5 instance size for those distros
-    default: '{% if distro in ["RHEL7"] %}c4.large{% else %}c5.large{% endif %}'
+    default: '{% if distro in ["RHEL7"] %}c4.xlarge{% else %}c5.xlarge{% endif %}'
   environment:
     type: string
     enum:

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -16,7 +16,7 @@ parameters:
   instance_type:
     type: string
     # There is no AMI which supports new C5 instance size for those distros
-    default: '{% if distro in ["RHEL7"] %}c4.large{% else %}c5.large{% endif %}'
+    default: '{% if distro in ["RHEL7"] %}c4.xlarge{% else %}c5.xlarge{% endif %}'
   environment:
     type: string
     enum:


### PR DESCRIPTION
This pull request updates EC2 instances we use for end to end tests - it uses instance type with more CPU cores and memory.

Right now our end to end tests are very slow (~25-30 minutes) which is a big problem because it makes developer cycle and feedback loop very slow and making even a small change requires a very long time commitment due to the slow end to end tests.

I think we can get some quick wins by using a larger instance (but will see once this PR is merged).

I did some quick calculations based on our recent e2e tests usage and I don't think this should add more than 50$ to the monthly bill. I believe we still have a good amount of credentials and even if it would add more, I would argue it's worth it (in aggregate we waste much more developer time on waiting for the tests vs this $).

I also wanted to have a look at our EC2 billing dashboard, but sadly I don't have my AWS account MFA codes. I will do that once I get EC2 instance again.

I also hope my DB performance optimizations changes will also help a bit since a lot of those end to end workflows do return quite a lot of data and we do run 4 workflows concurrency which puts even larger load on that DB code (but to be able to fully reap those changes, we will of course also need to upgrade our CI/CD node itself).