### PR TITLE
Disable PR rules

### DIFF
--- a/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_centos7_on_st2_pr.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_e2e_test_centos7_on_st2_pr
 description: Run CentOS7 end-to-end test on 'StackStorm/st2' PRs and update GitHub status
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_e2e_test_centos8_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_centos8_on_st2_pr.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_e2e_test_centos8_on_st2_pr
 description: Run CentOS8 end-to-end test on 'StackStorm/st2' PRs and update GitHub status
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_e2e_test_ubuntu18_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_ubuntu18_on_st2_pr.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_e2e_test_ubuntu18_on_st2_pr
 description: Run Ubuntu18 end-to-end test on 'StackStorm/st2' PRs and update GitHub status
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event

--- a/rules/st2_pkg_e2e_test_ubuntu20_on_st2_pr.yaml
+++ b/rules/st2_pkg_e2e_test_ubuntu20_on_st2_pr.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_e2e_test_ubuntu20_on_st2_pr
 description: Run Ubuntu20 end-to-end test on 'StackStorm/st2' PRs and update GitHub status
 pack: st2ci
-enabled: true
+enabled: false
 
 trigger:
     type: circle_ci.build_event


### PR DESCRIPTION
Disable the on-commit PR commit builds as they are currently having to be manually disabled whenever we do an update of the CI pack.
Given the desire to check on the AWS costings, suggest we disable them by default in the pack.