### PR TITLE
Move EL7 unstable to CentOS 7 to see if fix CI issues

### DIFF
--- a/actions/st2_pkg_test_and_promote.meta.yaml
+++ b/actions/st2_pkg_test_and_promote.meta.yaml
@@ -15,7 +15,6 @@ parameters:
     type: string
     required: true
     enum:
-      - RHEL7
       - CENTOS7
       - RHEL8
       - UBUNTU18

--- a/actions/st2_pkg_test_and_promote.meta.yaml
+++ b/actions/st2_pkg_test_and_promote.meta.yaml
@@ -16,6 +16,7 @@ parameters:
     required: true
     enum:
       - RHEL7
+      - CENTOS7
       - RHEL8
       - UBUNTU18
       - UBUNTU20

--- a/actions/workflows/st2_pkg_test_and_promote.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote.yaml
@@ -12,6 +12,7 @@ input:
   - pkg_env: staging
   - distro_to_distro_version_map:
       RHEL7: el/7
+      CENTOS7: el/7
       RHEL8: el/8
       UBUNTU18: ubuntu/bionic
       UBUNTU20: ubuntu/focal

--- a/rules/st2_pkg_test_and_promote_unstable_el7.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7.yaml
@@ -18,6 +18,6 @@ action:
   ref: st2ci.st2_pkg_test_and_promote
   parameters:
     hostname: st2-pkg-unstable-el7
-    distro: RHEL7
+    distro: CENTOS7
     release: unstable
     chatops: true


### PR DESCRIPTION
Problems seen on the RHEL7 E2E builds with mirrors. As we want to move to CentOS7 anyway to reduce AWS costs, moved EL7 over to CentOS7 now.