### PR TITLE
Introduce windows_instance_type parameter and use ROCKY8 for e2e tests

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -5,8 +5,8 @@
 ```
 st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-u18 distro=UBUNTU18 pkg_env=staging release=stable version={{st2kv.system.st2_this_release}} chatops=true
 st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-u20 distro=UBUNTU20 pkg_env=staging release=stable version={{st2kv.system.st2_this_release}} chatops=true
-st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-el7 distro=RHEL7 pkg_env=staging release=stable version={{st2kv.system.st2_this_release}} chatops=true
-st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-el8 distro=RHEL8 pkg_env=staging release=stable version={{st2kv.system.st2_this_release}} chatops=true
+st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-el7 distro=CENTOS7 pkg_env=staging release=stable version={{st2kv.system.st2_this_release}} chatops=true
+st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-el8 distro=ROCKY8 pkg_env=staging release=stable version={{st2kv.system.st2_this_release}} chatops=true
 ```
 
 ### End-to-End Upgrade Tests ###
@@ -14,6 +14,6 @@ st2 run --async st2ci.st2_pkg_e2e_test hostname=st2-pkg-staging-stable-el8 distr
 ```
 st2 run --async st2ci.st2_pkg_upgrade_e2e_test hostname=st2-pkg-upgrade-staging-stable-u18 distro=UBUNTU18 pkg_env=staging release=stable upgrade_from_version={{st2kv.system.st2_prev_release}} upgrade_to_version={{st2kv.system.st2_this_release}} chatops=true
 st2 run --async st2ci.st2_pkg_upgrade_e2e_test hostname=st2-pkg-upgrade-staging-stable-u20 distro=UBUNTU20 pkg_env=staging release=stable upgrade_from_version={{st2kv.system.st2_prev_release}} upgrade_to_version={{st2kv.system.st2_this_release}} chatops=true
-st2 run --async st2ci.st2_pkg_upgrade_e2e_test hostname=st2-pkg-upgrade-staging-stable-el7 distro=RHEL7 pkg_env=staging release=stable upgrade_from_version={{st2kv.system.st2_prev_release}} upgrade_to_version={{st2kv.system.st2_this_release}} chatops=true
-st2 run --async st2ci.st2_pkg_upgrade_e2e_test hostname=st2-pkg-upgrade-staging-stable-el8 distro=RHEL8 pkg_env=staging release=stable upgrade_from_version={{st2kv.system.st2_prev_release}} upgrade_to_version={{st2kv.system.st2_this_release}} chatops=true
+st2 run --async st2ci.st2_pkg_upgrade_e2e_test hostname=st2-pkg-upgrade-staging-stable-el7 distro=CENTOS7 pkg_env=staging release=stable upgrade_from_version={{st2kv.system.st2_prev_release}} upgrade_to_version={{st2kv.system.st2_this_release}} chatops=true
+st2 run --async st2ci.st2_pkg_upgrade_e2e_test hostname=st2-pkg-upgrade-staging-stable-el8 distro=ROCKY8 pkg_env=staging release=stable upgrade_from_version={{st2kv.system.st2_prev_release}} upgrade_to_version={{st2kv.system.st2_this_release}} chatops=true
 ```

--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -45,6 +45,9 @@ parameters:
     enum:
       - windows2016
     default: windows2016
+  windows_instance_type:
+    type: string
+    default: t2.medium
   role:
     type: string
     default: cislave

--- a/actions/st2_pkg_promote_all.meta.yaml
+++ b/actions/st2_pkg_promote_all.meta.yaml
@@ -10,8 +10,8 @@ parameters:
     type: string
     required: true
     enum:
-      - RHEL7
-      - RHEL8
+      - CENTOS7
+      - ROCKY8
       - UBUNTU18
       - UBUNTU20
   release:

--- a/actions/st2_pkg_test_and_promote.meta.yaml
+++ b/actions/st2_pkg_test_and_promote.meta.yaml
@@ -16,7 +16,7 @@ parameters:
     required: true
     enum:
       - CENTOS7
-      - RHEL8
+      - ROCKY8
       - UBUNTU18
       - UBUNTU20
   release:

--- a/actions/st2_pkg_upgrade_e2e_test.meta.yaml
+++ b/actions/st2_pkg_upgrade_e2e_test.meta.yaml
@@ -45,6 +45,9 @@ parameters:
     enum:
       - windows2016
     default: windows2016
+  windows_instance_type:
+    type: string
+    default: t2.medium
   role:
     type: string
     default: cislave

--- a/actions/workflows/st2_pkg_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_e2e_test.yaml
@@ -10,6 +10,7 @@ input:
   - keyfile
   - distro
   - windows_distro
+  - windows_instance_type
   - role
   - release
   - st2tests_version
@@ -174,7 +175,7 @@ tasks:
     action: st2cd.create_vm_windows
     input:
       hostname: <% ctx().windows_hostname %>
-      instance_type: <% ctx().instance_type %>
+      instance_type: <% ctx().windows_instance_type %>
       environment: <% ctx().environment %>
       dns_zone: <% ctx().dns_zone %>
       distro: <% ctx().windows_distro %>

--- a/actions/workflows/st2_pkg_promote_all.yaml
+++ b/actions/workflows/st2_pkg_promote_all.yaml
@@ -6,8 +6,8 @@ input:
   - version
   - pkg_env: staging
   - distro_to_distro_version_map:
-      RHEL7: el/7
-      RHEL8: el/8
+      CENTOS7: el/7
+      ROCKY8: el/8
       UBUNTU18: ubuntu/bionic
       UBUNTU20: ubuntu/focal
   - promoted_st2: false

--- a/actions/workflows/st2_pkg_test_and_promote.yaml
+++ b/actions/workflows/st2_pkg_test_and_promote.yaml
@@ -14,6 +14,7 @@ input:
       RHEL7: el/7
       CENTOS7: el/7
       RHEL8: el/8
+      ROCKY8: el/8
       UBUNTU18: ubuntu/bionic
       UBUNTU20: ubuntu/focal
   - promoted_st2: false

--- a/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
+++ b/actions/workflows/st2_pkg_upgrade_e2e_test.yaml
@@ -9,6 +9,7 @@ input:
   - keyfile
   - distro
   - windows_distro
+  - windows_instance_type
   - role
   - release
   - upgrade_from_version
@@ -187,7 +188,7 @@ tasks:
     action: st2cd.create_vm_windows
     input:
       hostname: <% ctx().windows_hostname %>
-      instance_type: <% ctx().instance_type %>
+      instance_type: <% ctx().windows_instance_type %>
       environment: <% ctx().environment %>
       dns_zone: <% ctx().dns_zone %>
       distro: <% ctx().windows_distro %>

--- a/rules/st2_pkg_test_and_promote_unstable_el8.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el8.yaml
@@ -18,6 +18,6 @@ action:
   ref: st2ci.st2_pkg_test_and_promote
   parameters:
     hostname: st2-pkg-unstable-el8
-    distro: RHEL8
+    distro: ROCKY8
     release: unstable
     chatops: true


### PR DESCRIPTION
Use ROCKY8 instead of RHEL8 for E2E and upgrade workflows
Introduce windows_instance_type parameter so can use different size of windows instance type to ST2
Default windows instance type to t2.medium as starting point