### PR TITLE
Do unstable builds only twice a week and use smaller windows size

### DIFF
--- a/actions/st2_pkg_e2e_test.meta.yaml
+++ b/actions/st2_pkg_e2e_test.meta.yaml
@@ -47,7 +47,7 @@ parameters:
     default: windows2016
   windows_instance_type:
     type: string
-    default: t2.medium
+    default: t2.small
   role:
     type: string
     default: cislave

--- a/rules/st2_pkg_test_and_promote_unstable_el7.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7.yaml
@@ -11,6 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
+    day_of_week: "1,4"
 
 criteria: {}
 

--- a/rules/st2_pkg_test_and_promote_unstable_el8.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el8.yaml
@@ -11,6 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
+    day_of_week: "1,4"
 
 criteria: {}
 

--- a/rules/st2_pkg_test_and_promote_unstable_u18.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u18.yaml
@@ -11,6 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
+    day_of_week: "1,4"
 
 criteria: {}
 

--- a/rules/st2_pkg_test_and_promote_unstable_u20.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u20.yaml
@@ -11,6 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
+    day_of_week: "1,4"
 
 criteria: {}
 


### PR DESCRIPTION
Run builds on Monday and Thursday, and decrease size of windows AMI