### PR TITLE
Move  days of unstable runs

### DIFF
--- a/rules/st2_pkg_test_and_promote_unstable_el7.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el7.yaml
@@ -11,7 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
-    day_of_week: "1,4"
+    day_of_week: "2,3"
 
 criteria: {}
 

--- a/rules/st2_pkg_test_and_promote_unstable_el8.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_el8.yaml
@@ -11,7 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
-    day_of_week: "1,4"
+    day_of_week: "2,3"
 
 criteria: {}
 

--- a/rules/st2_pkg_test_and_promote_unstable_u18.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u18.yaml
@@ -11,7 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
-    day_of_week: "1,4"
+    day_of_week: "2,3"
 
 criteria: {}
 

--- a/rules/st2_pkg_test_and_promote_unstable_u20.yaml
+++ b/rules/st2_pkg_test_and_promote_unstable_u20.yaml
@@ -11,7 +11,7 @@ trigger:
     hour: 8
     minute: 0
     second: 0
-    day_of_week: "1,4"
+    day_of_week: "2,3"
 
 criteria: {}
 


### PR DESCRIPTION
Changing days of builds as follows (times based on US/Pacific):
* Tues @ 18:00 Orphan run (cicd repo)
* Wed @ 6:00 Stable run (cd repo - no change)
* Wed @ 8:00 Unstable run (ci repo)
* Wed @ 18:00 Orphan run (cicd repo)
* Thur @ 8:00 Unstable run (ci repo)
* Thur @ 18:00 Orphan run (cicd repo)



If this runs ok, then propose that we have AWS Lambda control the EC2 instance with:
* Start Tues@16:00
* Stop Thurs@20:00
Therefore reducing to 52 hrs a week instead of 168.

This then means each week we still have 2 unstable, and 1 stable. We have orphan run after each day of running CIs but also at startup - in case of any problems previous week. Should enable servers to be up long enough to debug any problems.